### PR TITLE
Apply filters based on admin role. Hide vote count from non-admins.

### DIFF
--- a/app/controllers/CandidatesController.php
+++ b/app/controllers/CandidatesController.php
@@ -10,7 +10,7 @@ class CandidatesController extends \BaseController {
     $this->candidate = $candidate;
     $this->candidateValidator = $candidateValidator;
 
-    $this->beforeFilter('role:admin', ['only' => ['edit', 'update']]);
+    $this->beforeFilter('role:admin', ['except' => ['index', 'show']]);
   }
 
   /**

--- a/app/controllers/CategoriesController.php
+++ b/app/controllers/CategoriesController.php
@@ -9,6 +9,8 @@ class CategoriesController extends \BaseController {
   {
     $this->category = $category;
     $this->categoryValidator = $categoryValidator;
+
+    $this->beforeFilter('role:admin', ['except' => ['show']]);
   }
 
   /**

--- a/app/views/candidates/show.blade.php
+++ b/app/views/candidates/show.blade.php
@@ -8,7 +8,7 @@
   <p>{{{ $candidate->description }}}</p>
   @endif
 
-  @if($votes)
+  @if(Auth::user() && Auth::user()->hasRole('admin') && $votes)
   <h4>{{{$vote_count }}} {{{ str_plural('vote', $vote_count)}}}</h4>
   <ul>
   @forelse ($votes as $vote)
@@ -20,13 +20,17 @@
   @endif
 
   <h4>Your Vote</h4>
-  @if (Auth::user()->canVote($candidate))
-    {{ Form::open(['route' => 'votes.store']) }}
-    {{ Form::hidden('candidate_id', $candidate->id) }}
-    {{ Form::submit('Vote', ['class' => 'btn']) }}
-    {{ Form::close() }}
+  @if(Auth::user())
+    @if (Auth::user()->canVote($candidate))
+      {{ Form::open(['route' => 'votes.store']) }}
+      {{ Form::hidden('candidate_id', $candidate->id) }}
+      {{ Form::submit('Vote', ['class' => 'btn']) }}
+      {{ Form::close() }}
+    @else
+      You've already voted today!
+    @endif
   @else
-    You've already voted today!
+    {{ link_to_route('login', 'Sign in') }} to vote!
   @endif
 
 
@@ -41,7 +45,9 @@
   @endif
 
   <h4>Actions</h4>
-  <p>{{ link_to_route('candidates.edit', 'Edit Candidate', [$candidate->slug], ['class' => 'btn secondary']) }}</p>
+  @if(Auth::user() && Auth::user()->hasRole('admin'))
+    <p>{{ link_to_route('candidates.edit', 'Edit Candidate', [$candidate->slug], ['class' => 'btn secondary']) }}</p>
+  @endif
   <p>{{ link_to_route('candidates.index', 'Go Back') }}</p>
 
 @stop

--- a/app/views/categories/show.blade.php
+++ b/app/views/categories/show.blade.php
@@ -3,7 +3,7 @@
 @section('content')
   <h3>{{{ $category->name }}}</h3>
 
-  @if( !Auth::user()->canVoteInCategory($category))
+  @if( Auth::user() && !Auth::user()->canVoteInCategory($category))
   <div class="messages">You can't vote again in this category yet.</div>
   @endif
 
@@ -16,8 +16,9 @@
   @endforelse
   </ul>
 
-  <h4>Actions</h4>
-  <p>{{ link_to_route('categories.edit', 'Edit Category', [$category->slug], ['class' => 'btn secondary']) }}</p>
-  <p>{{ link_to_route('categories.index', 'Go Back') }}</p>
+  @if(Auth::user() && Auth::user()->hasRole('admin'))
+    <h4>Actions</h4>
+    <p>{{ link_to_route('categories.edit', 'Edit Category', [$category->slug], ['class' => 'btn secondary']) }}</p>
+  @endif
 
 @stop

--- a/app/views/layout.blade.php
+++ b/app/views/layout.blade.php
@@ -37,13 +37,17 @@
     </div>
 
     <footer class="chrome--footer">
+
+    @if(Auth::user() && Auth::user()->hasRole('admin'))
     <div class="col js-footer-col">
       <h4>Models</h4>
       <ul>
           <li>{{ link_to_route('candidates.index', 'Candidates') }}</li>
           <li>{{ link_to_route('categories.index', 'Categories') }}</li>
+          <li>{{ link_to_route('users.index', 'Users') }}</li>
       </ul>
     </div>
+    @endif
 
     <div class="col js-footer-col">
       <h4>User</h4>


### PR DESCRIPTION
# Changes
- Filters candidate and category actions based on `admin` role added in #28.
- Remove links from UI to things the current user is not allowed to do.

References #25.

/cc @angaither 
