### PR TITLE
Apparently Otwell gets angry without a remember_token.

### DIFF
--- a/app/database/migrations/2014_11_12_160110_remember_token.php
+++ b/app/database/migrations/2014_11_12_160110_remember_token.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RememberToken extends Migration {
+
+  /**
+   * Run the migrations.
+   *
+   * @return void
+   */
+  public function up()
+  {
+    Schema::table('users', function(Blueprint $table)
+    {
+        $table->rememberToken();
+    });
+  }
+
+  /**
+   * Reverse the migrations.
+   *
+   * @return void
+   */
+  public function down()
+  {
+    Schema::table('users', function(Blueprint $table)
+    {
+        $table->dropColumn('remember_token');
+    });
+  }
+
+}


### PR DESCRIPTION
the column needs to be in the db, even though it's not actually used. 
Fixes #55
