### PR TITLE
Improve tagline line-break on tablet.

### DIFF
--- a/app/assets/stylesheets/regions/_navigation.scss
+++ b/app/assets/stylesheets/regions/_navigation.scss
@@ -21,6 +21,10 @@ nav.primary {
     color: $gray;
     text-align: center;
     padding: $base-spacing;
+
+    @include media('medium') {
+      padding: $base-spacing (8 * $base-spacing);
+    }
   }
 
   ul {


### PR DESCRIPTION
# Changes
- Improve where line breaks on tablet. Little bit magic number-y, but it makes iPad view a lot nicer.
# Screenshots
#### Before:

![screen shot 2014-11-20 at 2 51 25 pm](https://cloud.githubusercontent.com/assets/583202/5131827/e46d55e2-70c4-11e4-8a83-02ae6dc7430c.png)
#### After:

![screen shot 2014-11-20 at 2 51 15 pm](https://cloud.githubusercontent.com/assets/583202/5131826/e1d702e2-70c4-11e4-9001-2a567170f5c8.png)
