### PR TITLE
Only administrators should be able to see the full list of candidates.

### DIFF
--- a/app/controllers/CandidatesController.php
+++ b/app/controllers/CandidatesController.php
@@ -10,7 +10,7 @@ class CandidatesController extends \BaseController {
     $this->candidate = $candidate;
     $this->candidateValidator = $candidateValidator;
 
-    $this->beforeFilter('role:admin', ['except' => ['index', 'show']]);
+    $this->beforeFilter('role:admin', ['except' => ['show']]);
   }
 
   /**


### PR DESCRIPTION
# Changes
- Restricts full index of candidates to administrators. Non-admin users should be viewing candidates through categories.
