### PR TITLE
Redirect to candidate page on failed validation. Fixes #157.

### DIFF
--- a/app/controllers/SessionsController.php
+++ b/app/controllers/SessionsController.php
@@ -51,7 +51,18 @@ class SessionsController extends \BaseController {
     // Use the user login/create method.
     else {
       $input = Input::only('first_name', 'email', 'phone', 'birthdate', 'candidate_id');
-      $this->userSessionValidator->validate($input);
+
+      try {
+        $this->userSessionValidator->validate($input);
+      } catch(Laracasts\Validation\FormValidationException $exception) {
+        // If there is a form validation error, show form errors on candidate page.
+        $candidate = Candidate::find($input['candidate_id']);
+        return Redirect::route('candidates.show', [$candidate->slug])->withInput()
+          ->withErrors($exception->getErrors())
+          ->withFlashMessage('There were some problems with that submission. Try again!')
+          ->with('flash_message_type', 'error');
+      }
+
       return $this->userLogin($input);
     }
 


### PR DESCRIPTION
# Changes
- Redirects to the candidate page on failed validation. This way users can fix their form input without having to scroll and find their candidate in the category list again.
# Notes

This is real messy. Form Requests in Laravel 5 will make this a lot cleaner to handle, since each form request can have its own `response()` method to customize what happens on a failed validation. Until then... :cactus: 

/cc @angaither 
