### PR TITLE
Properly escape HTML input in tile template.

### DIFF
--- a/app/views/candidates/tile.blade.php
+++ b/app/views/candidates/tile.blade.php
@@ -1,5 +1,5 @@
 <li>
-  <article class="tile" data-id="{{ $candidate->id }}" data-description="{{ $candidate->description }}" data-twitter="{{ $candidate->present()->twitter }}">
+  <article class="tile" data-id="{{{ $candidate->id }}}" data-description="{{{ $candidate->description }}}" data-twitter="{{{ $candidate->present()->twitter }}}">
     <a class="wrapper {{ isset($drawer) ? 'js-drawer-link' : '' }}" href="{{{ route('candidates.show', [$candidate->slug]) }}}">
       <div class="tile__meta">
         <h1>{{{ $candidate->name }}}</h1>


### PR DESCRIPTION
# Changes
- Properly escape HTML input so quotes don't asplode things. Or worse! Fixes #169.

/cc @angaither 
