### PR TITLE
Fixes issue where only one link placeholder was being replaced.

### DIFF
--- a/app/assets/javascripts/drawer.js
+++ b/app/assets/javascripts/drawer.js
@@ -61,7 +61,7 @@ $('.js-drawer-link').on('click', function(e) {
     name: $tile.find('h1').text(),
     description: $tile.data('description'),
     image: $tile.find('img').attr('src'),
-    form: $("#form-template").html().replace('CANDIDATE_NAME', name).replace('TWITTER_NAME', twitter).replace('CANDIDATE_LINK', link)
+    form: $("#form-template").html().replace('CANDIDATE_NAME', name).replace('TWITTER_NAME', twitter).replace(/CANDIDATE_LINK/g, link)
   });
 
   var $details = $('<div class="tile__details"><div class="tile__details__inner">' + details + '</div></div>');


### PR DESCRIPTION
# Changes
- Replace more than one instance of `CANDIDATE_LINK` in the template string. 

Fixes #166. (This is a bandaid. See #171.)
