### PR TITLE
Client side vote language

### DIFF
--- a/app/assets/javascripts/drawer.js
+++ b/app/assets/javascripts/drawer.js
@@ -61,6 +61,8 @@ $('.js-drawer-link').on('click', function(e) {
     .replace(/CANDIDATE_NAME/g, name)
     .replace(/TWITTER_NAME/g, twitter)
     .replace(/CANDIDATE_LINK/g, link)
+    .replace('Thanks for voting!', 'You\'ve already voted in this category.');
+
   var details = template({
     name: $tile.find('h1').text(),
     description: $tile.data('description'),


### PR DESCRIPTION
# Changes
- When viewing vote form in the drawer, replaces "Thanks for voting!" string with "You've already voted in this category". This is a temporary fix until we refactor the form to be generated client-side as well.

Fixes #185.
