### PR TITLE
Fix fatal error on international registration

### DIFF
--- a/app/models/User.php
+++ b/app/models/User.php
@@ -50,6 +50,10 @@ class User extends Eloquent implements UserInterface, RemindableInterface {
    */
   public function setPhoneAttribute($phone)
   {
+    // Skip mutator if attribute is null.
+    if(is_null($phone)) return;
+
+    // Otherwise, remove all non-numeric characters.
     $this->attributes['phone'] = preg_replace('/[^0-9]/','', $phone);
   }
 


### PR DESCRIPTION
# Changes
- Fixes issue where phone number mutator would change a null value into an empty string, and therefore fail unique database constraint on the phone number column for international users.

Fixes #200.

/cc @angaither 
