### PR TITLE
Cache category listing & clear cache on any category changes.

### DIFF
--- a/app/composers.php
+++ b/app/composers.php
@@ -5,7 +5,7 @@
  */
 View::composer('layout', function($view)
 {
-  $categories = Category::all();
+  $categories = Category::rememberForever('categories')->get();
   $settings = App::make('SettingsRepository')->all();
   return $view->with('settings', $settings)->with('categories', $categories);
 });

--- a/app/models/Category.php
+++ b/app/models/Category.php
@@ -7,6 +7,18 @@ class Category extends Eloquent implements SluggableInterface {
 
   use SluggableTrait;
 
+  public static function boot()
+  {
+    parent::boot();
+
+    Category::saved(function($category)
+    {
+      // Clear categories cache whenever model is updated
+      Cache::forget('categories');
+    });
+
+  }
+
   /**
    * The attributes which may be mass-assigned.
    *


### PR DESCRIPTION
# Changes
- Cache category list so it doesn't require a query on each page load.

For review: @angaither 
