### PR TITLE
Add Capistrano task to clear cache on deploys.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,8 +33,13 @@ namespace :deploy do
     run "cd #{release_path} && php artisan migrate --force"
   end
 
+  task :artisan_cache_clear do
+    run "cd #{release_path} && php artisan cache:clear"
+  end
+
 end
 
 after "deploy:update", "deploy:cleanup"
 after "deploy:symlink", "deploy:link_folders"
 after "deploy:link_folders", "deploy:artisan_migrate"
+after "deploy:artisan_migrate", "deploy:artisan_cache_clear"


### PR DESCRIPTION
# Changes
- Adds a Capistrano task to clear Laravel's cache on deploy. Fixes #68.

/cc @angaither @mshmsh5000 
