### PR TITLE
Don't escape the site tagline, to allow for links.

### DIFF
--- a/app/views/partials/navigation.blade.php
+++ b/app/views/partials/navigation.blade.php
@@ -4,7 +4,7 @@
   @if(Session::has('flash_message'))
     <div id="message" class="messages {{ Session::get('flash_message_type', '') }}">{{ Session::get('flash_message') }}</div>
   @else
-    <p class="navigation__tagline">{{{ $settings['tagline'] }}}</p>
+    <p class="navigation__tagline">{{ $settings['tagline'] }}</p>
   @endif
 
   <ul>


### PR DESCRIPTION
Fixes #267
