### PR TITLE
Candidate admin

### DIFF
--- a/app/Http/Controllers/CandidatesController.php
+++ b/app/Http/Controllers/CandidatesController.php
@@ -21,31 +21,37 @@ class CandidatesController extends \Controller
      */
     public function index()
     {
-//        // @TODO We need an administrative view for this.
-//        // Get optional request params.
-//        $sort_by = Request::get('sort_by');
-//        $direction = Request::get('direction');
-//        $filter_by = Request::get('filter_by');
-//
-//        $query = DB::table('candidates')
-//            ->join('categories', 'categories.id', '=', 'candidates.category_id')
-//            ->join('votes', 'candidates.id', '=', 'votes.candidate_id')
-//            ->select('candidates.name as name', 'candidates.slug', 'candidates.id', 'categories.name as category', DB::raw('COUNT(votes.id) as votes'))
-//            ->groupBy('candidates.name');
-//        if ($sort_by) {
-//            $query->orderBy($sort_by, $direction);
-//        } else {
-//            $query->orderBy('votes', 'DESC');
-//        }
-//        if ($filter_by) {
-//            $query->where('category_id', $filter_by);
-//        }
-//
-//        $candidates = $query->get();
+        // Show admin interface instead for administrators.
+        if(Auth::check() && Auth::user()->hasRole('admin')) {
+            return $this->adminIndex();
+        }
+
         $type = get_login_type();
         $categories = Category::with('candidates')->get();
 
         return view('candidates.index', compact('categories', 'type'));
+    }
+
+    /**
+     * Display administrative view for candidates.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function adminIndex(){
+        // Get optional request params.
+        $sort_by = (Request::get('sort_by') ? Request::get('sort_by') : 'votes');
+        $direction = (Request::get('direction') ? Request::get('direction') : 'DESC');
+
+        $candidates = DB::table('candidates')
+            ->join('categories', 'categories.id', '=', 'candidates.category_id')
+            ->join('votes', 'candidates.id', '=', 'votes.candidate_id')
+            ->select('candidates.name as name', 'candidates.slug', 'candidates.id', 'categories.name as category', DB::raw('COUNT(votes.id) as votes'))
+            ->groupBy('candidates.name')
+            ->orderBy($sort_by, $direction)
+            ->get();
+
+        return view('candidates.adminIndex', compact('candidates'));
+
     }
 
 

--- a/app/Http/Controllers/CandidatesController.php
+++ b/app/Http/Controllers/CandidatesController.php
@@ -21,8 +21,9 @@ class CandidatesController extends \Controller
      */
     public function index()
     {
-        // Show admin interface instead for administrators.
-        if(Auth::check() && Auth::user()->hasRole('admin')) {
+        // Show admin interface instead for administrators. Admin users can
+        // use the `?guest=1` query parameter to bypass the admin view.
+        if(Auth::check() && Auth::user()->hasRole('admin') && !Request::get('guest')) {
             return $this->adminIndex();
         }
 

--- a/app/Http/Controllers/CandidatesController.php
+++ b/app/Http/Controllers/CandidatesController.php
@@ -40,16 +40,24 @@ class CandidatesController extends \Controller
      */
     public function adminIndex(){
         // Get optional request params.
-        $sort_by = (Request::get('sort_by') ? Request::get('sort_by') : 'votes');
-        $direction = (Request::get('direction') ? Request::get('direction') : 'DESC');
+        $sort_by = Request::get('sort_by');
+        $direction = Request::get('direction');
 
-        $candidates = DB::table('candidates')
+        $query = DB::table('candidates')
             ->join('categories', 'categories.id', '=', 'candidates.category_id')
             ->join('votes', 'candidates.id', '=', 'votes.candidate_id')
             ->select('candidates.name as name', 'candidates.slug', 'candidates.id', 'categories.name as category', DB::raw('COUNT(votes.id) as votes'))
-            ->groupBy('candidates.name')
-            ->orderBy($sort_by, $direction)
-            ->get();
+            ->groupBy('candidates.name');
+
+        // If a sorting method & direction are provided, order by them.
+        if ($sort_by && $direction) {
+            $query->orderBy($sort_by, $direction);
+        }
+
+        // Within given sorting method, always list in descending vote order.
+        $query->orderBy('votes', 'DESC');
+
+        $candidates = $query->get();
 
         return view('candidates.adminIndex', compact('candidates'));
 

--- a/app/Http/Middleware/Administrator.php
+++ b/app/Http/Middleware/Administrator.php
@@ -1,27 +1,10 @@
 <?php namespace App\Http\Middleware;
 
+use Auth;
 use Closure;
-use Illuminate\Contracts\Auth\Guard;
 
 class Administrator
 {
-
-    /**
-     * The Guard implementation.
-     *
-     * @var Guard
-     */
-    protected $auth;
-
-    /**
-     * Create a new filter instance.
-     *
-     * @param  Guard $auth
-     */
-    public function __construct(Guard $auth)
-    {
-        $this->auth = $auth;
-    }
 
     /**
      * Handle an incoming request.
@@ -32,7 +15,7 @@ class Administrator
      */
     public function handle($request, Closure $next)
     {
-        if ($this->auth->user()->hasRole('admin')) {
+        if (!Auth::user()->hasRole('admin')) {
             if ($request->ajax()) {
                 return response('Unauthorized.', 401);
             } else {
@@ -42,4 +25,5 @@ class Administrator
 
         return $next($request);
     }
+
 }

--- a/app/Http/helpers.php
+++ b/app/Http/helpers.php
@@ -1,21 +1,6 @@
 <?php
 
 /**
- * Add an active class to current page's menu item.
- */
-function highlighted_link_to_route($route, $text, $params = [], $forceOnPath = null)
-{
-    $url = route($route, $params);
-
-    $class = '';
-    if (Request::url() == $url || Request::path() == $forceOnPath) {
-        $class = 'is-active';
-    }
-
-    return link_to_route($route, $text, $params, ['class' => $class]);
-}
-
-/**
  * Return contents of Fastly's GeoIP country code header.
  * @return string|null Country Code, or null if header is not set.
  */
@@ -66,18 +51,26 @@ function facebook_intent($url)
 }
 
 /**
- * A helper function to used to sort candidates.
+ * Generate relative links for sorting tabular data.
+ * @param $column string Column to sort by
+ * @return string
  */
-function sort_candidates_by($column, $body)
+function sort_url($column)
 {
     $direction = (Request::get('direction') == 'asc') ? 'desc' : 'asc';
-    return link_to_route('candidates.index', $body, ['sort_by' => $column, 'direction' => $direction]);
+    return '?sort_by=' . e($column) . '&direction=' . e($direction);
 }
 
 /**
- * A helper function to used to sort candidates.
+ * Return a class to indicate the current sorting method.
+ * @param $column Column to indicate sorting status of
+ * @return string
  */
-function filter_candidates_by($status, $body)
-{
-    return link_to_route('candidates.index', $body, ['filter_by' => $status]);
+function sort_class($column) {
+    $sortColumn = Request::get('sort_by');
+    $sortClass = (Request::get('direction') == 'asc') ? 'is-sorted-asc' : 'is-sorted-desc';
+
+    if($column !== $sortColumn) return '';
+
+    return $sortClass;
 }

--- a/resources/assets/sass/base/_typography.scss
+++ b/resources/assets/sass/base/_typography.scss
@@ -80,12 +80,12 @@ a {
   text-decoration: none;
 
   &:hover {
-    color: lighten($cyan, 10%);
+    color: lighten($cyan, 30%);
     text-decoration: underline;
   }
 
   &:active {
-    color: darken($cyan, 10%);
+    color: darken($cyan, 20%);
     outline: none;
   }
 }

--- a/resources/assets/sass/components/_pagination.scss
+++ b/resources/assets/sass/components/_pagination.scss
@@ -11,11 +11,3 @@
     color: $gray;
   }
 }
-
-.is-sorted-asc:after {
-  content: ' \25B2';
-}
-
-.is-sorted-desc:after {
-  content: ' \25BC';
-}

--- a/resources/assets/sass/components/_pagination.scss
+++ b/resources/assets/sass/components/_pagination.scss
@@ -11,3 +11,11 @@
     color: $gray;
   }
 }
+
+.is-sorted-asc:after {
+  content: ' \25B2';
+}
+
+.is-sorted-desc:after {
+  content: ' \25BC';
+}

--- a/resources/assets/sass/components/_table.scss
+++ b/resources/assets/sass/components/_table.scss
@@ -11,6 +11,18 @@ table {
 
 thead {
   font-weight: $weight-bold;
+
+  .is-sorted-asc:after {
+    content: ' \25B2';
+  }
+
+  .is-sorted-desc:after {
+    content: ' \25BC';
+  }
+
+  a:hover {
+    text-decoration: none;
+  }
 }
 
 tr {

--- a/resources/views/candidates/adminIndex.blade.php
+++ b/resources/views/candidates/adminIndex.blade.php
@@ -4,6 +4,7 @@
     <div class="wrapper">
         <div class="row">
             <h1 class="highlighted">All Candidates</h1>
+            <p><strong>Hey, {{ Auth::user()->first_name }}!</strong> You can sort and edit candidates from here, or <a href="?guest=1">view as a guest</a>.</p>
         </div>
 
         <table>

--- a/resources/views/candidates/adminIndex.blade.php
+++ b/resources/views/candidates/adminIndex.blade.php
@@ -1,0 +1,37 @@
+@extends('app')
+
+@section('content')
+    <div class="wrapper">
+        <div class="row">
+            <h1 class="highlighted">All Candidates</h1>
+        </div>
+
+        <table>
+            <thead>
+            <tr>
+                <td><a class="{{ sort_class('name') }}" href="{{ sort_url('name') }}">Name</a></td>
+                <td><a class="{{ sort_class('category') }}" href="{{ sort_url('category') }}">Category</a></td>
+                <td><a class="{{ sort_class('votes') }}" href="{{ sort_url('votes') }}">Votes</a></td>
+                <td>&nbsp;</td>
+                <td>&nbsp;</td>
+            </tr>
+            </thead>
+            @forelse($candidates as $candidate)
+                <tr>
+                    <td>{{ $candidate->name }}</td>
+                    <td>{{ $candidate->category }}</td>
+                    <td>{{ $candidate->votes }}</td>
+                    <td><a href="{{ route('candidates.edit', [$candidate->slug]) }}">edit</a></td>
+                    <td>
+                        {!! Form::open(['route' => 'winners.store']) !!}
+                            {!! Form::hidden('id', $candidate->id) !!}
+                            {!! Form::submit('Mark as Winner') !!}
+                        {!! Form::close() !!}
+                    </td>
+                </tr>
+            @empty
+                <div class="empty">No users... yet!</div>
+            @endforelse
+        </table>
+    </div>
+@stop


### PR DESCRIPTION
# Changes
 - Closes #295. Restores candidate administrative view functionality, after removing it when we updated the homepage to show all candidates. 
 - Also adds some prettier styles for displaying which column is being sorted. :art: 
 - Fixes `admin` middleware to properly check if users are an admin. Also directly uses `Auth` facade instead of newfangled Laravel 5 `Guard` thing, since the `$guard->user()` method returns an interface that only includes built-in authentication related methods, rather than the full user.

For review: @angaither 

# Screenshot
![screen shot 2015-04-23 at 4 54 15 pm](https://cloud.githubusercontent.com/assets/583202/7307878/bd569a4e-e9dd-11e4-8948-d8a6c8242e37.png)
