### PR TITLE
Event classes

### DIFF
--- a/app/Events/UserCastFirstVote.php
+++ b/app/Events/UserCastFirstVote.php
@@ -5,9 +5,10 @@ use App\Events\Event;
 use Illuminate\Queue\SerializesModels;
 use Vote;
 
-class UserCastFirstVote extends Event {
+class UserCastFirstVote extends Event
+{
 
-	use SerializesModels;
+    use SerializesModels;
 
     public $first_name;
 
@@ -27,8 +28,8 @@ class UserCastFirstVote extends Event {
      * Create a new event instance.
      * @param Vote $vote
      */
-	public function __construct(Vote $vote)
-	{
+    public function __construct(Vote $vote)
+    {
         $this->first_name = $vote->user()->first_name;
         $this->email = $vote->user()->email;
         $this->phone = $vote->user()->phone;
@@ -37,6 +38,6 @@ class UserCastFirstVote extends Event {
 
         $this->candidate_id = $vote->candidate()->id;
         $this->candidate_name = $vote->candidate()->name;
-	}
+    }
 
 }

--- a/app/Events/UserCastFirstVote.php
+++ b/app/Events/UserCastFirstVote.php
@@ -1,0 +1,42 @@
+<?php namespace App\Events;
+
+use App\Events\Event;
+
+use Illuminate\Queue\SerializesModels;
+use Vote;
+
+class UserCastFirstVote extends Event {
+
+	use SerializesModels;
+
+    public $first_name;
+
+    public $email;
+
+    public $phone;
+
+    public $birthdate;
+
+    public $country_code;
+
+    public $candidate_id;
+
+    public $candidate_name;
+
+    /**
+     * Create a new event instance.
+     * @param Vote $vote
+     */
+	public function __construct(Vote $vote)
+	{
+        $this->first_name = $vote->user()->first_name;
+        $this->email = $vote->user()->email;
+        $this->phone = $vote->user()->phone;
+        $this->birthdate = $vote->user()->birthdateTimestamp();
+        $this->country_code = $vote->user()->country_code;
+
+        $this->candidate_id = $vote->candidate()->id;
+        $this->candidate_name = $vote->candidate()->name;
+	}
+
+}

--- a/app/Events/UserCastVote.php
+++ b/app/Events/UserCastVote.php
@@ -4,16 +4,17 @@ use App\Events\Event;
 
 use Illuminate\Queue\SerializesModels;
 
-class UserCastVote extends Event {
+class UserCastVote extends Event
+{
 
-	use SerializesModels;
+    use SerializesModels;
 
-	/**
-	 * Create a new event instance.
-	 */
-	public function __construct()
-	{
-		//
-	}
+    /**
+     * Create a new event instance.
+     */
+    public function __construct()
+    {
+        //
+    }
 
 }

--- a/app/Events/UserCastVote.php
+++ b/app/Events/UserCastVote.php
@@ -1,0 +1,19 @@
+<?php namespace App\Events;
+
+use App\Events\Event;
+
+use Illuminate\Queue\SerializesModels;
+
+class UserCastVote extends Event {
+
+	use SerializesModels;
+
+	/**
+	 * Create a new event instance.
+	 */
+	public function __construct()
+	{
+		//
+	}
+
+}

--- a/app/Events/UserRegistered.php
+++ b/app/Events/UserRegistered.php
@@ -4,9 +4,10 @@ use App\Events\Event;
 
 use Illuminate\Queue\SerializesModels;
 
-class UserRegistered extends Event {
+class UserRegistered extends Event
+{
 
-	use SerializesModels;
+    use SerializesModels;
 
     public $first_name;
 
@@ -22,13 +23,13 @@ class UserRegistered extends Event {
      * Create a new event instance.
      * @param \User $user
      */
-	public function __construct(\User $user)
-	{
+    public function __construct(\User $user)
+    {
         $this->first_name = $user->first_name;
         $this->email = $user->email;
         $this->phone = $user->phone;
         $this->birthdate = $user->birthdate_timestamp();
         $this->country_code = $user->country_code;
-	}
+    }
 
 }

--- a/app/Events/UserRegistered.php
+++ b/app/Events/UserRegistered.php
@@ -1,0 +1,34 @@
+<?php namespace App\Events;
+
+use App\Events\Event;
+
+use Illuminate\Queue\SerializesModels;
+
+class UserRegistered extends Event {
+
+	use SerializesModels;
+
+    public $first_name;
+
+    public $email;
+
+    public $phone;
+
+    public $birthdate;
+
+    public $country_code;
+
+    /**
+     * Create a new event instance.
+     * @param \User $user
+     */
+	public function __construct(\User $user)
+	{
+        $this->first_name = $user->first_name;
+        $this->email = $user->email;
+        $this->phone = $user->phone;
+        $this->birthdate = $user->birthdate_timestamp();
+        $this->country_code = $user->country_code;
+	}
+
+}

--- a/app/Handlers/Events/SendFirstVoteEmail.php
+++ b/app/Handlers/Events/SendFirstVoteEmail.php
@@ -1,0 +1,60 @@
+<?php namespace App\Handlers\Events;
+
+use App\Events\UserCastFirstVote;
+use MessageBroker;
+
+class SendFirstVoteEmail {
+
+	/**
+	 * Handle the event.
+	 *
+	 * @param  UserCastFirstVote  $event
+	 * @return void
+	 */
+	public function handle(UserCastFirstVote $event)
+	{
+        // Don't send messages locally.
+        if (app()->environment('local')) {
+            return;
+        }
+
+        // Configure the message broker connection
+        $credentials = Config::get('services.message_broker.credentials');
+        $config = Config::get('services.message_broker.config');
+        $config['routingKey'] = env('VOTE_ROUTING_KEY', 'votingapp.event.vote');
+        $broker = new MessageBroker($credentials, $config);
+
+        // Sign user up for transaction messages.
+        $payload = [
+            // User information
+            'first_name' => $event->first_name,
+            'email' => $event->email,
+            'mobile' => $event->phone,
+            'birthdate_timestamp' => $event->birthdate, // Message Broker expects UNIX timestamp
+            'country_code' => $event->country_code,
+
+            // Candidate information.
+            'candidate_id' => $event->candidate_id,
+            'candidate_name' => $event->candidate_name,
+
+            // Request specific information
+            'activity' => env('VOTE_ACTIVITY', 'votingapp_vote'),
+            'application_id' => 201,
+            'activity_timestamp' => time(),
+            'email_template' => env('VOTE_TEMPLATE', 'mb-votingapp-vote'),
+            'email_tags' => [
+                0 => env('VOTE_EMAIL_TAG', 'votingapp_signup'),
+            ],
+            'mailchimp_grouping_id' => env('MAILCHIMP_GROUP_ID'),
+            'mailchimp_group_name' => env('MAILCHIMP_GROUP_NAME'),
+            'mc_opt_in_path_id' => env('MC_OPT_IN_PATH'),
+            'merge_vars' => [
+                'FNAME' => $event->first_name
+            ]
+        ];
+
+        $payload = serialize($payload);
+        $broker->publishMessage($payload);
+	}
+
+}

--- a/app/Handlers/Events/SendFirstVoteEmail.php
+++ b/app/Handlers/Events/SendFirstVoteEmail.php
@@ -3,16 +3,17 @@
 use App\Events\UserCastFirstVote;
 use MessageBroker;
 
-class SendFirstVoteEmail {
+class SendFirstVoteEmail
+{
 
-	/**
-	 * Handle the event.
-	 *
-	 * @param  UserCastFirstVote  $event
-	 * @return void
-	 */
-	public function handle(UserCastFirstVote $event)
-	{
+    /**
+     * Handle the event.
+     *
+     * @param  UserCastFirstVote $event
+     * @return void
+     */
+    public function handle(UserCastFirstVote $event)
+    {
         // Don't send messages locally.
         if (app()->environment('local')) {
             return;
@@ -55,6 +56,6 @@ class SendFirstVoteEmail {
 
         $payload = serialize($payload);
         $broker->publishMessage($payload);
-	}
+    }
 
 }

--- a/app/Handlers/Events/SendWelcomeEmail.php
+++ b/app/Handlers/Events/SendWelcomeEmail.php
@@ -1,0 +1,58 @@
+<?php namespace App\Handlers\Events;
+
+use App\Events\UserRegistered;
+use MessageBroker;
+use Config;
+
+class SendWelcomeEmail {
+
+	/**
+	 * Handle the event.
+	 *
+	 * @param  UserRegistered  $event
+	 * @return void
+	 */
+	public function handle(UserRegistered $event)
+	{
+        // Don't send messages locally.
+        if (app()->environment('local')) {
+            return;
+        }
+
+        // Configure the message broker connection
+        $credentials = Config::get('services.message_broker.credentials');
+        $config = Config::get('services.message_broker.config');
+        $config['routingKey'] = env('REGISTER_ROUTING_KEY', 'votingapp.user.registration');
+        $broker = new MessageBroker($credentials, $config);
+
+        // Sign user up for transaction messages.
+        $payload = [
+            // User information
+            'first_name' => $event->first_name,
+            'email' => $event->email,
+            'mobile' => $event->phone,
+            'birthdate_timestamp' => $event->birthdate, // Message Broker expects UNIX timestamp
+            'country_code' => $event->country_code,
+
+            // Request specific information
+            'activity' => env('REGISTER_ACTIVITY', 'votingapp_signup'),
+            'application_id' => 201,
+            'activity_timestamp' => time(),
+            'email_template' => env('REGISTER_TEMPLATE', 'mb-votingapp-signup'),
+            'email_tags' => [
+                0 => env('REGISTER_EMAIL_TAG', 'votingapp_signup'),
+            ],
+            'mailchimp_grouping_id' => env('MAILCHIMP_GROUP_ID'),
+            'mailchimp_group_name' => env('MAILCHIMP_GROUP_NAME'),
+            'mc_opt_in_path_id' => env('MC_OPT_IN_PATH'),
+            'merge_vars' => [
+                'FNAME' => $event->first_name
+            ],
+            'user_registration_source' => env('REGISTER_MB_SOURCE', 'votingapp')
+        ];
+
+        $payload = serialize($payload);
+        $broker->publishMessage($payload);
+	}
+
+}

--- a/app/Handlers/Events/SendWelcomeEmail.php
+++ b/app/Handlers/Events/SendWelcomeEmail.php
@@ -4,16 +4,17 @@ use App\Events\UserRegistered;
 use MessageBroker;
 use Config;
 
-class SendWelcomeEmail {
+class SendWelcomeEmail
+{
 
-	/**
-	 * Handle the event.
-	 *
-	 * @param  UserRegistered  $event
-	 * @return void
-	 */
-	public function handle(UserRegistered $event)
-	{
+    /**
+     * Handle the event.
+     *
+     * @param  UserRegistered $event
+     * @return void
+     */
+    public function handle(UserRegistered $event)
+    {
         // Don't send messages locally.
         if (app()->environment('local')) {
             return;
@@ -53,6 +54,6 @@ class SendWelcomeEmail {
 
         $payload = serialize($payload);
         $broker->publishMessage($payload);
-	}
+    }
 
 }

--- a/app/Handlers/Events/UpdateRegistrationStats.php
+++ b/app/Handlers/Events/UpdateRegistrationStats.php
@@ -1,14 +1,15 @@
 <?php namespace App\Handlers\Events;
 
-class UpdateRegistrationStats {
+class UpdateRegistrationStats
+{
 
-	/**
-	 * Handle the event.
-	 *
-	 * @return void
-	 */
-	public function handle()
-	{
+    /**
+     * Handle the event.
+     *
+     * @return void
+     */
+    public function handle()
+    {
         if (app()->environment('local')) {
             return;
         }
@@ -19,6 +20,6 @@ class UpdateRegistrationStats {
             stathat_ez_count($stathat_key, env('STATHAT_APP_NAME', 'votingapp') . ' - user register', 1);
         }
 
-	}
+    }
 
 }

--- a/app/Handlers/Events/UpdateRegistrationStats.php
+++ b/app/Handlers/Events/UpdateRegistrationStats.php
@@ -1,0 +1,24 @@
+<?php namespace App\Handlers\Events;
+
+class UpdateRegistrationStats {
+
+	/**
+	 * Handle the event.
+	 *
+	 * @return void
+	 */
+	public function handle()
+	{
+        if (app()->environment('local')) {
+            return;
+        }
+
+        // Log this event to stathat.
+        $stathat_key = Config::get('services.stathat.key');
+        if ($stathat_key) {
+            stathat_ez_count($stathat_key, env('STATHAT_APP_NAME', 'votingapp') . ' - user register', 1);
+        }
+
+	}
+
+}

--- a/app/Handlers/Events/UpdateVotingStats.php
+++ b/app/Handlers/Events/UpdateVotingStats.php
@@ -1,14 +1,15 @@
 <?php namespace App\Handlers\Events;
 
-class UpdateVotingStats {
+class UpdateVotingStats
+{
 
-	/**
-	 * Handle the event.
-	 *
-	 * @return void
-	 */
-	public function handle()
-	{
+    /**
+     * Handle the event.
+     *
+     * @return void
+     */
+    public function handle()
+    {
         if (app()->environment('local')) {
             return;
         }
@@ -18,6 +19,6 @@ class UpdateVotingStats {
         if ($stathat_key) {
             stathat_ez_count($stathat_key, env('STATHAT_APP_NAME', 'votingapp') . ' - vote', 1);
         }
-	}
+    }
 
 }

--- a/app/Handlers/Events/UpdateVotingStats.php
+++ b/app/Handlers/Events/UpdateVotingStats.php
@@ -1,0 +1,23 @@
+<?php namespace App\Handlers\Events;
+
+class UpdateVotingStats {
+
+	/**
+	 * Handle the event.
+	 *
+	 * @return void
+	 */
+	public function handle()
+	{
+        if (app()->environment('local')) {
+            return;
+        }
+
+        // Log this event to stathat.
+        $stathat_key = Config::get('services.stathat.key');
+        if ($stathat_key) {
+            stathat_ez_count($stathat_key, env('STATHAT_APP_NAME', 'votingapp') . ' - vote', 1);
+        }
+	}
+
+}

--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -2,6 +2,9 @@
 
 use App\Http\Requests\UserSessionRequest;
 use App\Http\Requests\AdminSessionRequest;
+use App\Events\UserCastFirstVote;
+use App\Events\UserRegistered;
+
 
 class AuthController extends \Controller
 {
@@ -42,7 +45,8 @@ class AuthController extends \Controller
 
             $user = User::createNewUser($input);
             $newUserAccount = true;
-            Event::fire('user.create', [$user]);
+
+            event(new UserRegistered($user));
         }
 
         // Log in the user.
@@ -58,7 +62,7 @@ class AuthController extends \Controller
 
                 // Trigger a vote transactional message only for new users.
                 if ($newUserAccount) {
-                    Event::fire('first.vote', [$candidate, $user]);
+                    event(new UserCastFirstVote($vote));
                 }
 
                 return Redirect::to($url)->withFlashMessage('Welcome ' . $input['first_name'] . '. We got that vote!');

--- a/app/Models/Vote.php
+++ b/app/Models/Vote.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Events\UserCastVote;
 use Illuminate\Database\Eloquent\Model;
 use Carbon\Carbon;
 
@@ -31,6 +32,7 @@ class Vote extends Model
 
     /**
      * Assuming a user is eligible to vote, save the vote
+     * @returns Vote
      */
     public static function createIfEligible($candidate_id, $user_id)
     {
@@ -49,7 +51,8 @@ class Vote extends Model
             'user_id' => $user_id
         ]);
 
-        Event::fire('user.vote');
+        event(new UserCastVote($vote));
+
         return $vote;
     }
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -15,8 +15,15 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
-        'event.name' => [
-            'EventListener',
+        'App\Events\UserRegistered' => [
+            'App\Handlers\Events\SendWelcomeEmail',
+            'App\Handlers\Events\UpdateRegistrationStats',
+        ],
+        'App\Events\UserCastVote' => [
+            'App\Handlers\Events\UpdateVotingStats',
+        ],
+        'App\Events\UserCastFirstVote' => [
+            'App\Handlers\Events\SendFirstVoteEmail',
         ],
     ];
 
@@ -29,118 +36,5 @@ class EventServiceProvider extends ServiceProvider
     public function boot(DispatcherContract $events)
     {
         parent::boot($events);
-
-        // @TODO These should be in their own Event classes in App\Events
-
-        // An event listener that handles user votes.
-        Event::listen('first.vote', function ($candidate, $user) {
-            // Don't send messages locally.
-            if (App::environment('local')) {
-                return;
-            }
-            // Sign user up for transaction messages.
-            $credentials = Config::get('services.message_broker.credentials');
-            $config = Config::get('services.message_broker.config');
-            $config['routingKey'] = env('VOTE_ROUTING_KEY', 'votingapp.event.vote');
-
-            $mb = new MessageBroker($credentials, $config);
-
-            $payload = [
-                // User information
-                'first_name' => $user->first_name,
-                'email' => $user->email,
-                'mobile' => $user->phone,
-                'birthdate_timestamp' => $user->birthdate_timestamp(), // Message Broker expects UNIX timestamp
-                'country_code' => $user->country_code,
-
-                // Candidate information.
-                'candidate_id' => $candidate->id,
-                'candidate_name' => $candidate->name,
-
-                // Request specific information
-                'activity' => env('VOTE_ACTIVITY', 'votingapp_vote'),
-                'application_id' => 201,
-                'activity_timestamp' => time(),
-                'email_template' => env('VOTE_TEMPLATE', 'mb-votingapp-vote'),
-                'email_tags' => [
-                    0 => env('VOTE_EMAIL_TAG', 'votingapp_signup'),
-                ],
-                'mailchimp_grouping_id' => env('MAILCHIMP_GROUP_ID'),
-                'mailchimp_group_name' => env('MAILCHIMP_GROUP_NAME'),
-                'mc_opt_in_path_id' => env('MC_OPT_IN_PATH'),
-                'merge_vars' => [
-                    'FNAME' => $user->first_name
-                ]
-            ];
-
-            $payload = serialize($payload);
-            $mb->publishMessage($payload);
-
-            if (extension_loaded('newrelic')) {
-                newrelic_add_custom_parameter("user_birthdate", $user->birthdate_timestamp());
-            }
-
-
-        });
-
-        Event::listen('user.create', function ($user) {
-            // Don't send messages locally.
-            if (App::environment('local')) {
-                return;
-            }
-
-            //  // Log this event to stathat.
-            $stathat_key = Config::get('services.stathat.key');
-            if ($stathat_key) {
-                stathat_ez_count($stathat_key, env('STATHAT_APP_NAME', 'votingapp') . ' - user register', 1);
-            }
-
-            // Sign user up for transaction messages.
-            $credentials = Config::get('services.message_broker.credentials');
-            $config = Config::get('services.message_broker.config');
-            $config['routingKey'] = env('REGISTER_ROUTING_KEY', 'votingapp.user.registration');
-
-            $mb = new MessageBroker($credentials, $config);
-
-            $payload = [
-                // User information
-                'first_name' => $user->first_name,
-                'email' => $user->email,
-                'mobile' => $user->phone,
-                'birthdate_timestamp' => $user->birthdate_timestamp(), // Message Broker expects UNIX timestamp
-                'country_code' => $user->country_code,
-
-                // Request specific information
-                'activity' => env('REGISTER_ACTIVITY', 'votingapp_signup'),
-                'application_id' => 201,
-                'activity_timestamp' => time(),
-                'email_template' => env('REGISTER_TEMPLATE', 'mb-votingapp-signup'),
-                'email_tags' => [
-                    0 => env('REGISTER_EMAIL_TAG', 'votingapp_signup'),
-                ],
-                'mailchimp_grouping_id' => env('MAILCHIMP_GROUP_ID'),
-                'mailchimp_group_name' => env('MAILCHIMP_GROUP_NAME'),
-                'mc_opt_in_path_id' => env('MC_OPT_IN_PATH'),
-                'merge_vars' => [
-                    'FNAME' => $user->first_name
-                ],
-                'user_registration_source' => env('REGISTER_MB_SOURCE', 'votingapp')
-            ];
-
-            $payload = serialize($payload);
-            $mb->publishMessage($payload);
-
-        });
-
-        Event::listen('user.vote', function () {
-            if (App::environment('local')) {
-                return;
-            }
-            // Log this event to stathat.
-            $stathat_key = Config::get('services.stathat.key');
-            if ($stathat_key) {
-                stathat_ez_count($stathat_key, env('STATHAT_APP_NAME', 'votingapp') . ' - vote', 1);
-            }
-        });
     }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -14,6 +14,10 @@ return [
     |
     */
 
+    'stathat' => [
+        'key' => env('STATHAT_EZ_KEY')
+    ],
+
     'message_broker' => [
         'config' => [
             // Exchange options


### PR DESCRIPTION
# Changes
 - Split registration/vote events into Laravel 5 Event classes & handlers. Also separates stats & messaging handlers so things are more readable.
 - Restore `stathat` entry in services configuration that got lost in L5 migration.

For review: @angaither