### PR TITLE
Add candidate type setting.

### DIFF
--- a/app/Models/Candidate.php
+++ b/app/Models/Candidate.php
@@ -89,7 +89,7 @@ class Candidate extends Model implements SluggableInterface
     /**
      * Custom share name attribute
      *
-     * @return string twitter handle, or celeb name
+     * @return string twitter handle, or candidate name
      * @see $appends array
      */
     public function getShareNameAttribute()

--- a/database/migrations/2015_04_27_145556_AddCandidateTypeToSettings.php
+++ b/database/migrations/2015_04_27_145556_AddCandidateTypeToSettings.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddCandidateTypeToSettings extends Migration {
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::table('settings')->insert([
+            'key' => 'candidate_type',
+            'type' => 'text',
+            'value' => 'candidate',
+            'description' => 'The "type" of candidate being voted for (e.g. "celeb" or "athlete")',
+        ]);
+    }
+
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::table('settings')->delete(['key' => 'candidate_type']);
+    }
+
+}

--- a/resources/views/candidates/index.blade.php
+++ b/resources/views/candidates/index.blade.php
@@ -18,12 +18,12 @@
     @endforelse
 
     <div class="wrapper -narrow">
-        <h4>Was there a celeb we missed?</h4>
+        <h4>Was there a {{ $settings['candidate_type'] }} we missed?</h4>
 
         <p>
-            If you know a celeb who's done kickass things in the world, but don't see them on our list, let us know by
-            emailing <a href="mailto:writein@celebsgonegood.com">writein@celebsgonegood.com</a>. Make sure to
-            include the work they've done in 2014 for social good (in 140 characters or less). Thank you!
+            If you know a {{ $settings['candidate_type'] }} who's done kickass things in the world, but don't see them
+            on our list, let us know by emailing <a href="mailto:writein@celebsgonegood.com">writein@celebsgonegood.com</a>.
+            Make sure to include the work they've done in the past year for social good (in 140 characters or less). Thank you!
         </p>
     </div>
 

--- a/resources/views/categories/show.blade.php
+++ b/resources/views/categories/show.blade.php
@@ -32,12 +32,12 @@
     </div>
 
     <div class="wrapper -narrow">
-        <h4>Was there a celeb we missed?</h4>
+        <h4>Was there a {{ $settings['candidate_type'] }} we missed?</h4>
 
         <p>
-            If you know a celeb who's done kickass things in the world, but don't see them on our list, let us know by
-            emailing <a href="mailto:writein@celebsgonegood.com">writein@celebsgonegood.com</a>. Make sure to
-            include the work they've done in 2014 for social good (in 140 characters or less). Thank you!
+            If you know a {{ $settings['candidate_type'] }} who's done kickass things in the world, but don't see them
+            on our list, let us know by emailing <a href="mailto:writein@celebsgonegood.com">writein@celebsgonegood.com</a>.
+            Make sure to include the work they've done in the past year for social good (in 140 characters or less). Thank you!
         </p>
     </div>
 

--- a/resources/views/partials/metadata.blade.php
+++ b/resources/views/partials/metadata.blade.php
@@ -1,18 +1,18 @@
 {{-- General social metadata --}}
-<link rel="canonical" href="{{{ URL::current() }}}"/>
+<link rel="canonical" href="{{ URL::current() }}"/>
 <meta name="description"
-      content="@yield('meta_description', 'Vote for your favorite celebrity who has done kickass things in the world this year.')"/>
+      content="@yield('meta_description', 'Vote for your favorite ' . $settings['candidate_type'] . ' who has done kickass things in the world this year.')"/>
 
 {{-- Twitter --}}
 <meta name="twitter:site" content="@dosomething"/>
 <meta name="twitter:creator" content="@dosomething"/>
-<meta name="twitter:url" content="{{{ URL::current() }}}"/>
-<meta name="twitter:title" content="@yield('meta_title', 'Celebs Gone Good')"/>
+<meta name="twitter:url" content="{{ URL::current() }}"/>
+<meta name="twitter:title" content="@yield('meta_title', $settings['site_title'])"/>
 <meta name="twitter:description"
-      content="@yield('meta_description', 'Vote for your favorite celeb who has done kickass things in the world.')"/>
+      content="@yield('meta_description', 'Vote for your favorite ' . $settings['candidate_type']  . ' who has done kickass things in the world.')"/>
 <meta name="twitter:image" content="@yield('meta_image', URL::to('/dist/images/twitter-share.jpg'))"/>
 
 {{-- Facebook --}}
 <meta property="og:site_name" content="{{ $settings['site_title'] }}"/>
-<meta property="og:title" content="@yield('meta_title', 'Celebs Gone Good')"/>
+<meta property="og:title" content="@yield('meta_title', $settings['site_title'])"/>
 <meta property="og:image" content="@yield('meta_image', URL::to('/dist/images/fb-share.jpg'))"/>


### PR DESCRIPTION
# Changes
 - Closes #297. Removes hardcoded instances of the word "celeb", and instead references a setting for "candidate type". We can run this setting through [`str_plural`](http://laravel.com/docs/4.2/helpers#strings) if we ever need a plural form.

For review: @angaither 