### PR TITLE
Simplify settings view composer.

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -22,8 +22,8 @@ class SettingsController extends \Controller
      */
     public function index()
     {
-        $settings = $this->setting->get();
-        return view('settings.index', compact('settings'));
+        $settingsList = $this->setting->get();
+        return view('settings.index', compact('settingsList'));
     }
 
     /**
@@ -55,6 +55,8 @@ class SettingsController extends \Controller
 
         $setting->value = $request->get('value');
         $setting->save();
+
+        Cache::forget('settings');
 
         return redirect()->route('settings.index')->withFlashMessage('Setting updated.');
     }

--- a/app/Http/ViewComposers/SettingsComposer.php
+++ b/app/Http/ViewComposers/SettingsComposer.php
@@ -3,7 +3,7 @@
 use Illuminate\Contracts\View\View;
 use SettingsRepository;
 
-class LayoutComposer
+class SettingsComposer
 {
 
     /**

--- a/app/Providers/ComposerServiceProvider.php
+++ b/app/Providers/ComposerServiceProvider.php
@@ -14,7 +14,7 @@ class ComposerServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        View::composer(['app', 'candidates.index', 'candidates.show', 'candidates.voteForm', 'categories.show'], 'App\Http\ViewComposers\LayoutComposer');
+        View::composer(['*'], 'App\Http\ViewComposers\SettingsComposer');
     }
 
     /**

--- a/app/Repositories/SettingsRepository.php
+++ b/app/Repositories/SettingsRepository.php
@@ -4,12 +4,15 @@ class SettingsRepository
 {
 
     /**
-     * Return an array of all settings.
-     * @return array Key/value array of settings.
+     * Return a cached array of all settings.
+     * @return array - Key/value array of settings.
      */
     public function all()
     {
-        // @TODO: ->rememberForever('settings') deprecated in Laravel 5!
-        return DB::table('settings')->lists('value', 'key');
+        return Cache::rememberForever('settings', function() {
+            return DB::table('settings')->lists('value', 'key');
+        });
+
+
     }
 }

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -16,7 +16,7 @@
                 <td>&nbsp;</td>
             </tr>
             </thead>
-            @forelse($settings as $setting)
+            @forelse($settingsList as $setting)
                 <tr>
                     <td><strong>{{ $setting->key }}</strong></td>
                     <td>{!! $setting->pretty_value() !!}</td>


### PR DESCRIPTION
# Changes
 - Makes `$settings` object available in all views.
 - Caches settings so they don't hit the database on each page load.

For review: @angaither 