### PR TITLE
Fix Proxima Nova WOFF font URL.

### DIFF
--- a/resources/assets/sass/base/_fonts.scss
+++ b/resources/assets/sass/base/_fonts.scss
@@ -3,7 +3,7 @@
   font-family: "Proxima Nova";
   font-weight: 400;
   src: url("../assets/fonts/proxima-nova/ProximaNova-Regular.eot");
-  src: url("../assets/fonts/proxima-nova/ProximaNova-Regular.eot?") format("eot"), url("fonts/proxima-nova/ProximaNova-Regular.woff") format("woff");
+  src: url("../assets/fonts/proxima-nova/ProximaNova-Regular.eot?") format("eot"), url("../assets/fonts/proxima-nova/ProximaNova-Regular.woff") format("woff");
 }
 
 @font-face {


### PR DESCRIPTION
# Changes

Fixes the URL for Proxima Nova Regular's WOFF file, which was 404ing.

:dancer: 
