### PR TITLE
Allow overriding country code for debugging.

### DIFF
--- a/app/Http/helpers.php
+++ b/app/Http/helpers.php
@@ -7,6 +7,11 @@
  */
 function get_country_code()
 {
+    // Allow overriding country via query string, for debugging
+    if($queryOverride = app('request')->get('country')) {
+        return $queryOverride;
+    }
+
     return app('request')->server('HTTP_X_FASTLY_COUNTRY_CODE', null);
 }
 


### PR DESCRIPTION
# Changes

Allow overriding country code via a query string for debugging, for example `www.catsgonegood.com?country=GB` to teleport to the United Kingdom. :gb: 

/cc @DeeZone 
