### PR TITLE
Set the country code in the session.

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -17,6 +17,7 @@ class Kernel extends HttpKernel
         'Illuminate\Session\Middleware\StartSession',
         'Illuminate\View\Middleware\ShareErrorsFromSession',
         'VotingApp\Http\Middleware\VerifyCsrfToken',
+        'VotingApp\Http\Middleware\SetCountryCodeFromHeader',
         'VotingApp\Http\Middleware\SetLanguageFromHeader',
     ];
 

--- a/app/Http/Middleware/SetCountryCodeFromHeader.php
+++ b/app/Http/Middleware/SetCountryCodeFromHeader.php
@@ -1,0 +1,52 @@
+<?php namespace VotingApp\Http\Middleware;
+
+use Closure;
+
+class SetCountryCodeFromHeader {
+
+	/**
+	 * Handle an incoming request.
+	 *
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  \Closure  $next
+	 * @return mixed
+	 */
+	public function handle($request, Closure $next)
+	{
+        // Save country code in session if not set
+        if(!$request->session()->has('country_code')) {
+            $this->saveCountryCodeToSession($request, $this->getCountryCode($request));
+        };
+
+        // Allow overriding country via query string, for debugging
+        if($queryOverride = $request->get('country_code')) {
+            $this->saveCountryCodeToSession($request, $queryOverride);
+        }
+
+        return $next($request);
+	}
+
+    /**
+     * Get the country code from Fastly's GeoIP Header.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string|null
+     */
+    public function getCountryCode($request)
+    {
+        return $request->server('HTTP_X_FASTLY_COUNTRY_CODE', null);
+    }
+
+    /**
+     * Save the country code to the session.
+     *
+     * @param $request
+     * @param $countryCode
+     */
+    public function saveCountryCodeToSession($request, $countryCode)
+    {
+        $request->session()->put('country_code', $queryOverride);
+        $request->session()->save();
+    }
+
+}

--- a/app/Http/helpers.php
+++ b/app/Http/helpers.php
@@ -7,12 +7,7 @@
  */
 function get_country_code()
 {
-    // Allow overriding country via query string, for debugging
-    if($queryOverride = app('request')->get('country')) {
-        return $queryOverride;
-    }
-
-    return app('request')->server('HTTP_X_FASTLY_COUNTRY_CODE', null);
+    return session('country_code');
 }
 
 /**


### PR DESCRIPTION
# Changes

Set the country code in the session using a global middleware. This allows us to override country code in a `GET` request and then access during a later `POST` request in the same session.

This overrides what I did in #340.
