### PR TITLE
Use production build task on Wercker.

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -21,7 +21,7 @@ build:
       - wercker/bundle-install@1.1.1
       - script:
           name: build assets
-          code: gulp
+          code: gulp --production
 
 deploy:
   steps:


### PR DESCRIPTION
# Changes

Use `gulp --production` to build assets on Wercker, so we get nice minified builds.

/cc @blisteringherb 
