### PR TITLE
Add gender to Candidate model & first vote message payload

### DIFF
--- a/app/Handlers/Events/SendFirstVoteMessage.php
+++ b/app/Handlers/Events/SendFirstVoteMessage.php
@@ -67,7 +67,8 @@ class SendFirstVoteMessage
             $payload['merge_vars'] = [
                 'FNAME' => $event->user->first_name,
                 'CANDIDATE_NAME' => $event->candidate->name,
-                'CANDIDATE_LINK' => route('candidates.show', $event->candidate->slug)
+                'CANDIDATE_LINK' => route('candidates.show', $event->candidate->slug),
+                'GENDER' => $event->candidate->gender,
             ];
         }
 

--- a/app/Handlers/Events/SendFirstVoteMessage.php
+++ b/app/Handlers/Events/SendFirstVoteMessage.php
@@ -47,7 +47,7 @@ class SendFirstVoteMessage
             $payload['mobile_tags'] = [
                 env('APP_NAME_TAG', 'votingapp'),
                 $event->candidate->id,
-                $event->candidate->gender,
+                'GENDER_' . $event->candidate->gender,
             ];
         }
 
@@ -62,7 +62,7 @@ class SendFirstVoteMessage
             $payload['email_tags'] = [
                 env('APP_NAME_TAG', 'votingapp'),
                 $event->candidate->id,
-                $event->candidate->gender,
+                'GENDER_' . $event->candidate->gender,
             ];
             $payload['merge_vars'] = [
                 'FNAME' => $event->user->first_name,

--- a/app/Handlers/Events/SendFirstVoteMessage.php
+++ b/app/Handlers/Events/SendFirstVoteMessage.php
@@ -46,7 +46,8 @@ class SendFirstVoteMessage
             $payload['mc_opt_in_path_id'] = env('MC_OPT_IN_PATH');
             $payload['mobile_tags'] = [
                 env('APP_NAME_TAG', 'votingapp'),
-                $event->candidate->id
+                $event->candidate->id,
+                $event->candidate->gender,
             ];
         }
 
@@ -60,7 +61,8 @@ class SendFirstVoteMessage
             $payload['email_template'] = env('VOTE_TEMPLATE', 'mb-votingapp-vote');
             $payload['email_tags'] = [
                 env('APP_NAME_TAG', 'votingapp'),
-                $event->candidate->id
+                $event->candidate->id,
+                $event->candidate->gender,
             ];
             $payload['merge_vars'] = [
                 'FNAME' => $event->user->first_name,

--- a/app/Http/Controllers/CandidatesController.php
+++ b/app/Http/Controllers/CandidatesController.php
@@ -66,7 +66,7 @@ class CandidatesController extends Controller
         $query = DB::table('candidates')
             ->join('categories', 'categories.id', '=', 'candidates.category_id')
             ->leftJoin('votes', 'candidates.id', '=', 'votes.candidate_id')
-            ->select('candidates.name as name', 'candidates.slug', 'candidates.id', 'categories.name as category', DB::raw('COUNT(votes.id) as votes'))
+            ->select('candidates.name as name', 'candidates.slug', 'candidates.id', 'candidates.gender', 'categories.name as category', DB::raw('COUNT(votes.id) as votes'))
             ->groupBy('candidates.name');
 
         // If a sorting method & direction are provided, order by them.

--- a/app/Http/Controllers/CandidatesController.php
+++ b/app/Http/Controllers/CandidatesController.php
@@ -60,8 +60,8 @@ class CandidatesController extends Controller
      */
     public function adminIndex(Request $request){
         // Get optional request params.
-        $sort_by = $request->get('sort_by');
-        $direction = $request->get('direction');
+        $sort_by = $request->get('sort_by', 'name');
+        $direction = $request->get('direction', 'ASC');
 
         $query = DB::table('candidates')
             ->join('categories', 'categories.id', '=', 'candidates.category_id')

--- a/app/Models/Candidate.php
+++ b/app/Models/Candidate.php
@@ -16,7 +16,7 @@ class Candidate extends Model implements SluggableInterface
      * @var array
      */
     protected $fillable = [
-        'name', 'description', 'category_id', 'twitter', 'photo_source'
+        'name', 'description', 'category_id', 'gender', 'twitter', 'photo_source'
     ];
 
     /**

--- a/database/migrations/2015_06_11_145439_add_gender_to_candidates.php
+++ b/database/migrations/2015_06_11_145439_add_gender_to_candidates.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddGenderToCandidates extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+        Schema::table('candidates', function (Blueprint $table) {
+            $table->char('gender', 1)->after('description')->default('X');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('candidates', function (Blueprint $table) {
+            $table->dropColumn('gender');
+        });
+	}
+
+}

--- a/database/seeds/CandidatesTableSeeder.php
+++ b/database/seeds/CandidatesTableSeeder.php
@@ -19,6 +19,7 @@ class CandidatesTableSeeder extends Seeder
                     'name' => $faker->name(),
                     'description' => $faker->paragraph(2),
                     'category_id' => $category_id,
+                    'gender' => $faker->randomElement(['M', 'F', 'X'])
                 ]);
 
                 $image = $faker->file(base_path('database/seeds/images/candidates'), '/tmp');

--- a/resources/views/candidates/adminIndex.blade.php
+++ b/resources/views/candidates/adminIndex.blade.php
@@ -12,6 +12,7 @@
             <tr>
                 <td><a class="{{ sort_class('name') }}" href="{{ sort_url('name') }}">Name</a></td>
                 <td><a class="{{ sort_class('category') }}" href="{{ sort_url('category') }}">Category</a></td>
+                <td><a class="{{ sort_class('gender') }}" href="{{ sort_url('gender') }}">Gender</a></td>
                 <td><a class="{{ sort_class('votes') }}" href="{{ sort_url('votes') }}">Votes</a></td>
                 <td>&nbsp;</td>
                 <td>&nbsp;</td>
@@ -22,6 +23,7 @@
                 <tr>
                     <td>{{ $candidate->name }}</td>
                     <td>{{ $candidate->category }}</td>
+                    <td>{{ $candidate->gender }}</td>
                     <td>{{ $candidate->votes }}</td>
                     <td><a href="{{ route('candidates.show', [$candidate->slug]) }}">view</a></td>
                     <td><a href="{{ route('candidates.edit', [$candidate->slug]) }}">edit</a></td>

--- a/resources/views/candidates/form.blade.php
+++ b/resources/views/candidates/form.blade.php
@@ -13,5 +13,8 @@
 {!! Form::label('description') !!}
 {!! Form::textarea('description', null, ['rows' => '2']) !!}
 
+{!! Form::label('gender') !!}
+{!! Form::select('gender', ['M' => 'Male', 'F' => 'Female', 'X' => 'Neutral']) !!}
+
 {!! Form::label('twitter') !!}
 {!! Form::text('twitter', null, ['placeholder' => '@handle']) !!}


### PR DESCRIPTION
# Changes
- Adds a `gender` column to the Candidate model, with possible values `M`, `F`, or `X` (default).
- Add gender column in the admin view to make it easy to update & check values.
- Add gender to `mobile_tags` and `email_tags` payloads for Message Broker.

Fixes #345 and closes #310.

For review: @DeeZone 
