### PR TITLE
Pre-render React views on the server

### DIFF
--- a/app/Http/Controllers/CandidatesController.php
+++ b/app/Http/Controllers/CandidatesController.php
@@ -21,9 +21,11 @@ class CandidatesController extends Controller
         'image' => 'image',
     ];
 
-    public function __construct()
+    public function __construct(ReactService $react)
     {
         $this->middleware('admin', ['except' => ['index', 'show']]);
+
+        $this->react = $react;
     }
 
     /**
@@ -32,7 +34,7 @@ class CandidatesController extends Controller
      * @param Request $request
      * @return \Illuminate\Http\Response
      */
-    public function index(Request $request, ReactService $react)
+    public function index(Request $request)
     {
         $showAsGuest = Auth::check() && Auth::user()->admin && $request->get('guest');
 
@@ -51,7 +53,7 @@ class CandidatesController extends Controller
         $query = $request->get('query', '');
         $categories = Category::with('candidates')->get();
 
-        $gallery = $react->render('gallery', 'CandidateIndex', compact('categories', 'query'));
+        $gallery = $this->react->render('gallery', 'CandidateIndex', compact('categories', 'query'));
 
         return view('candidates.index', compact('gallery', 'categories'));
     }

--- a/app/Http/Controllers/CandidatesController.php
+++ b/app/Http/Controllers/CandidatesController.php
@@ -21,11 +21,9 @@ class CandidatesController extends Controller
         'image' => 'image',
     ];
 
-    public function __construct(ReactService $react)
+    public function __construct()
     {
         $this->middleware('admin', ['except' => ['index', 'show']]);
-
-        $this->react = $react;
     }
 
     /**
@@ -53,9 +51,9 @@ class CandidatesController extends Controller
         $query = $request->get('query', '');
         $categories = Category::with('candidates')->get();
 
-        $gallery = $this->react->render('gallery', 'CandidateIndex', compact('categories', 'query'));
+//        $gallery = app('react')->render('gallery', 'CandidateIndex', compact('categories', 'query'));
 
-        return view('candidates.index', compact('gallery', 'categories'));
+        return view('candidates.index', compact('categories', 'query'));
     }
 
     /**

--- a/app/Http/Controllers/CandidatesController.php
+++ b/app/Http/Controllers/CandidatesController.php
@@ -2,6 +2,7 @@
 
 use VotingApp\Models\Candidate;
 use VotingApp\Models\Category;
+use VotingApp\Services\ReactService;
 use Illuminate\Http\Request;
 use Auth;
 use DB;
@@ -31,7 +32,7 @@ class CandidatesController extends Controller
      * @param Request $request
      * @return \Illuminate\Http\Response
      */
-    public function index(Request $request)
+    public function index(Request $request, ReactService $react)
     {
         $showAsGuest = Auth::check() && Auth::user()->admin && $request->get('guest');
 
@@ -47,9 +48,12 @@ class CandidatesController extends Controller
             return view('candidates.index', ['categories' => []]);
         }
 
+        $query = $request->get('query', '');
         $categories = Category::with('candidates')->get();
 
-        return view('candidates.index', compact('categories'));
+        $gallery = $react->render('gallery', 'CandidateIndex', compact('categories', 'query'));
+
+        return view('candidates.index', compact('gallery', 'categories'));
     }
 
     /**

--- a/app/Http/Controllers/CandidatesController.php
+++ b/app/Http/Controllers/CandidatesController.php
@@ -51,8 +51,6 @@ class CandidatesController extends Controller
         $query = $request->get('query', '');
         $categories = Category::with('candidates')->get();
 
-//        $gallery = app('react')->render('gallery', 'CandidateIndex', compact('categories', 'query'));
-
         return view('candidates.index', compact('categories', 'query'));
     }
 

--- a/app/Http/Controllers/CategoriesController.php
+++ b/app/Http/Controllers/CategoriesController.php
@@ -3,7 +3,6 @@
 use Illuminate\Http\Request;
 use VotingApp\Models\Category;
 use VotingApp\Models\Winner;
-use VotingApp\Services\ReactService;
 
 class CategoriesController extends Controller
 {
@@ -16,10 +15,8 @@ class CategoriesController extends Controller
         'name' => 'required',
     ];
 
-    public function __construct(ReactService $react)
+    public function __construct()
     {
-        $this->react = $react;
-
         $this->middleware('admin', ['except' => ['show']]);
     }
 
@@ -72,9 +69,7 @@ class CategoriesController extends Controller
         $name = $category->name;
         $candidates = $category->candidates;
 
-        $gallery = $this->react->render('gallery', 'CategoryIndex', compact('name', 'candidates'));
-
-        return view('categories.show', compact('category', 'gallery', 'winners'));
+        return view('categories.show', compact('name', 'candidates', 'winners'));
     }
 
     /**

--- a/app/Http/Controllers/CategoriesController.php
+++ b/app/Http/Controllers/CategoriesController.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use VotingApp\Models\Category;
 use VotingApp\Models\Winner;
+use VotingApp\Services\ReactService;
 
 class CategoriesController extends Controller
 {
@@ -15,8 +16,10 @@ class CategoriesController extends Controller
         'name' => 'required',
     ];
 
-    public function __construct()
+    public function __construct(ReactService $react)
     {
+        $this->react = $react;
+
         $this->middleware('admin', ['except' => ['show']]);
     }
 
@@ -65,9 +68,13 @@ class CategoriesController extends Controller
      */
     public function show(Category $category)
     {
-        $candidates = $category->candidates;
         $winners = Winner::getCategoryWinners($category);
-        return view('categories.show', compact('category', 'candidates', 'winners'));
+        $name = $category->name;
+        $candidates = $category->candidates;
+
+        $gallery = $this->react->render('gallery', 'CategoryIndex', compact('name', 'candidates'));
+
+        return view('categories.show', compact('category', 'gallery', 'winners'));
     }
 
     /**

--- a/app/Providers/ReactServiceProvider.php
+++ b/app/Providers/ReactServiceProvider.php
@@ -1,0 +1,32 @@
+<?php namespace VotingApp\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use VotingApp\Services\ReactService;
+use Blade;
+
+class ReactServiceProvider extends ServiceProvider
+{
+
+    public function boot()
+    {
+        // Register blade `@react` helper function
+        Blade::extend(function($view, $compiler) {
+            $pattern = $compiler->createMatcher('react');
+            return preg_replace($pattern, '<?php echo app("react")->render$2; ?>', $view);
+        });
+    }
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $app = $this->app;
+        $app['react'] = $app->share(function ($app) {
+            return new ReactService($app['config']->get('services.react.url'));
+        });
+    }
+
+}

--- a/app/Services/ReactService.php
+++ b/app/Services/ReactService.php
@@ -39,7 +39,7 @@ class ReactService
         $response = $this->client->post($component, ['body' => json_encode($props)]);
         $renderedComponent = $response->getBody()->getContents();
 
-        $markup = '<div id="' . $id . '"">' . $renderedComponent . '</div>';
+        $markup = '<div data-rendered-component="' . $component .'" id="' . $id . '"">' . $renderedComponent . '</div>';
         $markup = $markup . '<script id="' . $id . '-props" type="application/json">' . json_encode($props) . '</script>';
 
         return $markup;

--- a/app/Services/ReactService.php
+++ b/app/Services/ReactService.php
@@ -13,10 +13,10 @@ class ReactService
      */
     protected $client;
 
-    public function __construct(Client $client)
+    public function __construct($url)
     {
         $this->client = new Client([
-            'base_url' => config('services.react.url'),
+            'base_url' => $url,
             'defaults' => [
                 'headers' => [
                     'Content-Type' => 'application/json',
@@ -29,18 +29,20 @@ class ReactService
     /**
      * Render a given React component with props.
      *
-     * @param $id
      * @param $component
      * @param $props
      * @return string - HTML
      */
-    public function render($id, $component, $props)
+    public function render($component, $props)
     {
-        $response = $this->client->post($component, ['body' => json_encode($props)]);
+        $propsJSON = json_encode($props);
+        $id = $component . md5($component . $propsJSON);
+
+        $response = $this->client->post($component, ['body' => $propsJSON]);
         $renderedComponent = $response->getBody()->getContents();
 
-        $markup = '<div data-rendered-component="' . $component .'" id="' . $id . '"">' . $renderedComponent . '</div>';
-        $markup = $markup . '<script id="' . $id . '-props" type="application/json">' . json_encode($props) . '</script>';
+        $markup = '<div data-rendered-component="' . $component .'" id="' . $id . '">' . $renderedComponent . '</div>';
+        $markup = $markup . '<script id="' . $id . '-props" type="application/json">' . $propsJSON . '</script>';
 
         return $markup;
     }

--- a/app/Services/ReactService.php
+++ b/app/Services/ReactService.php
@@ -38,8 +38,13 @@ class ReactService
         $propsJSON = json_encode($props);
         $id = $component . md5($component . $propsJSON);
 
-        $response = $this->client->post($component, ['body' => $propsJSON]);
-        $renderedComponent = $response->getBody()->getContents();
+        try {
+            $response = $this->client->post($component, ['body' => $propsJSON]);
+            $renderedComponent = $response->getBody()->getContents();
+        } catch(RequestException $e) {
+            app('log')->error('Unable to pre-render React view.', [$e]);
+            $renderedComponent = '';
+        }
 
         $markup = '<div data-rendered-component="' . $component .'" id="' . $id . '">' . $renderedComponent . '</div>';
         $markup = $markup . '<script id="' . $id . '-props" type="application/json">' . $propsJSON . '</script>';

--- a/app/Services/ReactService.php
+++ b/app/Services/ReactService.php
@@ -1,0 +1,48 @@
+<?php namespace VotingApp\Services;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use Exception;
+
+class ReactService
+{
+
+    /**
+     * The HTTP client
+     * @var \GuzzleHttp\Client
+     */
+    protected $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = new Client([
+            'base_url' => config('services.react.url'),
+            'defaults' => [
+                'headers' => [
+                    'Content-Type' => 'application/json',
+                    'Accept' => 'text/html',
+                ]
+            ]
+        ]);
+    }
+
+    /**
+     * Render a given React component with props.
+     *
+     * @param $id
+     * @param $component
+     * @param $props
+     * @return string - HTML
+     */
+    public function render($id, $component, $props)
+    {
+        $response = $this->client->post($component, ['body' => json_encode($props)]);
+        $renderedComponent = $response->getBody()->getContents();
+
+        $markup = '<div id="' . $id . '"">' . $renderedComponent . '</div>';
+        $markup = $markup . '<script id="' . $id . '-props" type="application/json">' . json_encode($props) . '</script>';
+
+        return $markup;
+    }
+
+}

--- a/bootstrap/react_server.js
+++ b/bootstrap/react_server.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/**
+ * Register the Babel require hook. This will transpile
+ * ES6 files to ES5 on-the-fly.
+ *
+ * @see https://babeljs.io/docs/usage/require/
+ */
+require('babel/register');
+
+/**
+ * Bootstrap our server process. This is responsible for
+ * pre-rendering React views for our templates.
+ */
+var app = require('../resources/assets/js/server');
+app.listen(3000, function() {
+  console.log('React renderer started on port 3000');
+});

--- a/config/app.php
+++ b/config/app.php
@@ -143,6 +143,7 @@ return [
         'VotingApp\Providers\BusServiceProvider',
         'VotingApp\Providers\ConfigServiceProvider',
         'VotingApp\Providers\EventServiceProvider',
+        'VotingApp\Providers\ReactServiceProvider',
         'VotingApp\Providers\RouteServiceProvider',
         'VotingApp\Providers\ValidationServiceProvider',
 

--- a/config/services.php
+++ b/config/services.php
@@ -14,6 +14,10 @@ return [
     |
     */
 
+    'react' => [
+        'url' => env('REACT_SERVER_URL', 'http://localhost:3000')
+    ],
+
     'stathat' => [
         'debug' => env('APP_DEBUG', false),
         'ez_key' => env('STATHAT_EZ_KEY')

--- a/package.json
+++ b/package.json
@@ -6,8 +6,11 @@
     "laravel-elixir": "1.0.1"
   },
   "dependencies": {
+    "babel": "^5.5.6",
+    "body-parser": "^1.12.4",
     "classnames": "^2.1.2",
     "dom-delegate": "^2.0.3",
+    "express": "^4.12.4",
     "html5shiv": "^3.7.2",
     "layzr.js": "^1.1.4",
     "lodash": "^3.9.3",

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -33,12 +33,23 @@ cutTheMustard(function() {
     // Initialize `data-method` link handler.
     methodLink.initialize();
 
-    // Render the gallery if we're on a gallery page
-    const gallery = document.getElementById('gallery');
-    if(gallery) {
-      const props = JSON.parse(document.getElementById('gallery-props').innerHTML);
-      React.render(React.createElement(CandidateIndex, props), gallery);
-    }
+    const components = {
+      'CandidateIndex': CandidateIndex,
+      'Gallery': Gallery
+    };
+
+    // Re-hydrate any rendered React components
+    const reactElements = document.querySelectorAll('*[data-rendered-component]');
+    Array.prototype.forEach.call(reactElements, function(el) {
+      const id = el.getAttribute('id');
+      const props = JSON.parse(document.getElementById(`${id}-props`).innerHTML);
+
+      const component = el.getAttribute('data-rendered-component');
+      if(components[component]) {
+        React.render(React.createElement(components[component], props), el);
+      }
+
+    });
 
   });
 });

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -36,8 +36,8 @@ cutTheMustard(function() {
     // Render the gallery if we're on a gallery page
     const gallery = document.getElementById('gallery');
     if(gallery) {
-      const categories= JSON.parse(document.getElementById('gallery-json').innerHTML);
-      React.render(<CandidateIndex categories={categories} />, gallery);
+      const props = JSON.parse(document.getElementById('gallery-props').innerHTML);
+      React.render(React.createElement(CandidateIndex, props), gallery);
     }
 
   });

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -10,6 +10,7 @@ import shareLink from './utilities/share-link';
 
 // Components
 import CandidateIndex from './components/CandidateIndex';
+import CategoryIndex from './components/CategoryIndex';
 
 /**
  * Cut the mustard, wait for DOM load, & start the application.
@@ -35,7 +36,7 @@ cutTheMustard(function() {
 
     const components = {
       'CandidateIndex': CandidateIndex,
-      'Gallery': Gallery
+      'CategoryIndex': CategoryIndex
     };
 
     // Re-hydrate any rendered React components

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -6,6 +6,7 @@ import confirm from './utilities/confirm';
 import formLoader from './utilities/form-loader';
 import methodLink from './utilities/method-link';
 import cutTheMustard from './utilities/mustard';
+import rehydrate from './utilities/rehydrate';
 import shareLink from './utilities/share-link';
 
 // Components
@@ -34,22 +35,10 @@ cutTheMustard(function() {
     // Initialize `data-method` link handler.
     methodLink.initialize();
 
-    const components = {
+    // Rehydrate any pre-rendered React components on the page
+    rehydrate({
       'CandidateIndex': CandidateIndex,
       'CategoryIndex': CategoryIndex
-    };
-
-    // Re-hydrate any rendered React components
-    const reactElements = document.querySelectorAll('*[data-rendered-component]');
-    Array.prototype.forEach.call(reactElements, function(el) {
-      const id = el.getAttribute('id');
-      const props = JSON.parse(document.getElementById(`${id}-props`).innerHTML);
-
-      const component = el.getAttribute('data-rendered-component');
-      if(components[component]) {
-        React.render(React.createElement(components[component], props), el);
-      }
-
     });
 
   });

--- a/resources/assets/js/components/CandidateIndex.js
+++ b/resources/assets/js/components/CandidateIndex.js
@@ -5,11 +5,11 @@ import { cloneDeep, includes } from 'lodash';
 
 class CandidateIndex extends React.Component {
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
-      query: '',
+      query: props.query || '',
       selectedItem: null
     };
 
@@ -75,7 +75,7 @@ class CandidateIndex extends React.Component {
 
     return (
       <div>
-        <SearchForm onChange={this.setQuery} />
+        <SearchForm onChange={this.setQuery} query={this.state.query} />
         {galleries}
       </div>
     );

--- a/resources/assets/js/components/CandidateIndex.js
+++ b/resources/assets/js/components/CandidateIndex.js
@@ -65,18 +65,24 @@ class CandidateIndex extends React.Component {
   render() {
     var _this = this;
     var galleries = this.props.categories.map(function(category) {
+      var candidates = _this.filteredCandidates(category.candidates, category.name)
+      if(candidates.length == 0) return;
+
       return (
         <div key={category.id} className='category'>
           <h2 className='gallery-heading'>{category.name}</h2>
-          <Gallery items={_this.filteredCandidates(category.candidates, category.name)} selectItem={_this.selectItem} selectedItem={_this.state.selectedItem} />
+          <Gallery items={candidates} selectItem={_this.selectItem} selectedItem={_this.state.selectedItem} />
         </div>
       );
     });
 
+    // Remove any empty galleries from the array
+    galleries = galleries.filter(function(gallery) { return typeof gallery != 'undefined' });
+
     return (
       <div>
         <SearchForm onChange={this.setQuery} query={this.state.query} />
-        {galleries}
+        {galleries.length ? galleries : <div className='gallery'><div className='empty'>No results!</div></div>}
       </div>
     );
   }

--- a/resources/assets/js/components/CandidateIndex.js
+++ b/resources/assets/js/components/CandidateIndex.js
@@ -65,24 +65,21 @@ class CandidateIndex extends React.Component {
   render() {
     var _this = this;
     var galleries = this.props.categories.map(function(category) {
-      var candidates = _this.filteredCandidates(category.candidates, category.name)
+      var candidates = _this.filteredCandidates(category.candidates, category.name);
       if(candidates.length == 0) return;
 
       return (
-        <div key={category.id} className='category'>
-          <h2 className='gallery-heading'>{category.name}</h2>
-          <Gallery items={candidates} selectItem={_this.selectItem} selectedItem={_this.state.selectedItem} />
-        </div>
+        <Gallery key={category.id} name={category.name} items={candidates} selectItem={_this.selectItem} selectedItem={_this.state.selectedItem} />
       );
     });
 
-    // Remove any empty galleries from the array
+    // Remove any null entries from the array
     galleries = galleries.filter(function(gallery) { return typeof gallery != 'undefined' });
 
     return (
       <div>
         <SearchForm onChange={this.setQuery} query={this.state.query} />
-        {galleries.length ? galleries : <div className='gallery'><div className='empty'>No results!</div></div>}
+        {galleries.length ? galleries : <Gallery />}
       </div>
     );
   }

--- a/resources/assets/js/components/CandidateIndex.js
+++ b/resources/assets/js/components/CandidateIndex.js
@@ -1,7 +1,7 @@
 import React from 'react/addons';
 import Gallery from './Gallery';
 import SearchForm from './SearchForm';
-import { cloneDeep, includes } from 'lodash';
+import includes from 'lodash/collection/includes';
 
 class CandidateIndex extends React.Component {
 

--- a/resources/assets/js/components/CategoryIndex.js
+++ b/resources/assets/js/components/CategoryIndex.js
@@ -1,0 +1,45 @@
+import React from 'react/addons';
+import Gallery from './Gallery';
+
+class CategoryIndex extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      selectedItem: null
+    };
+
+    this.selectItem = this.selectItem.bind(this);
+  }
+
+  /**
+   * Set or unset the selected item to show details for.
+   * @param query
+   */
+  selectItem(item) {
+    // De-select if trying to select the same item again.
+    if(this.state.selectedItem === item.props.candidate) {
+      this.setState({selectedItem: null});
+      return;
+    }
+
+    this.setState({selectedItem: item.props.candidate});
+  }
+
+  /**
+   * Render component.
+   * @returns {XML}
+   */
+  render() {
+    return (
+      <div className='category'>
+        <h2 className='gallery-heading'>{this.props.name}</h2>
+        <Gallery items={this.props.candidates} selectItem={this.selectItem} selectedItem={this.state.selectedItem} />
+      </div>
+    );
+  }
+
+}
+
+export default CategoryIndex;

--- a/resources/assets/js/components/Drawer.js
+++ b/resources/assets/js/components/Drawer.js
@@ -1,6 +1,6 @@
 import React from 'react/addons';
-const { CSSTransitionGroup } = React.addons;
 import CandidateDetailView from './CandidateDetailView';
+const { CSSTransitionGroup } = React.addons;
 
 class Drawer extends React.Component {
 
@@ -32,7 +32,7 @@ class Drawer extends React.Component {
     }
 
     return (
-      <CSSTransitionGroup transitionName="drawer-animation" transitionAppear={true} transitionLeave={true}>
+      <CSSTransitionGroup transitionName="drawer-animation">
         {drawer}
       </CSSTransitionGroup>
     )

--- a/resources/assets/js/components/Gallery.js
+++ b/resources/assets/js/components/Gallery.js
@@ -21,11 +21,11 @@ class Gallery extends React.Component {
    * @returns {number}
    */
   tilesPerRow() {
-    const width = window.innerWidth;
+    if(typeof window === 'undefined') return 4;
 
-    if(width > 1100) {
+    if(window.innerWidth > 1100) {
       return 4;
-    } else if(width > 660) {
+    } else if(window.innerWidth > 660) {
       return 3;
     } else {
       return 1;
@@ -40,13 +40,15 @@ class Gallery extends React.Component {
     var _this = this;
 
     // Update state whenever window width changes
-    window.addEventListener('resize', function() {
-      var itemsPerRow = _this.tilesPerRow();
+    if(window) {
+      window.addEventListener('resize', function() {
+        var itemsPerRow = _this.tilesPerRow();
 
-      if(_this.state.itemsPerRow !== itemsPerRow) {
-        _this.setState({ itemsPerRow: itemsPerRow });
-      }
-    });
+        if(_this.state.itemsPerRow !== itemsPerRow) {
+          _this.setState({ itemsPerRow: itemsPerRow });
+        }
+      });
+    }
   }
 
   /**

--- a/resources/assets/js/components/Gallery.js
+++ b/resources/assets/js/components/Gallery.js
@@ -2,8 +2,7 @@ import React from 'react/addons';
 import classNames from 'classnames';
 import { chunk } from 'lodash';
 
-import Tile from './Tile';
-import Drawer from './Drawer';
+import GalleryRow from './GalleryRow';
 
 class Gallery extends React.Component {
 
@@ -71,30 +70,7 @@ class Gallery extends React.Component {
     const chunkedItems = chunk(this.props.items, this.state.itemsPerRow);
 
     let rows = chunkedItems.map(function(row, index) {
-      // Build each tile in the row
-      let hasSelectedTile = false;
-      var tiles = row.map(function(candidate) {
-        const selected = candidate === _this.props.selectedItem;
-        if(selected) {
-          hasSelectedTile = selected;
-        }
-
-        return (
-          <li key={candidate.id} className='gallery__item'>
-            <Tile candidate={candidate} selected={selected} onClick={_this.props.selectItem} />
-          </li>
-        );
-      });
-
-      // Return the row
-      return (
-        <div key={index}>
-          <div className='gallery__row'>
-          {tiles}
-          </div>
-          <Drawer isOpen={hasSelectedTile} candidate={_this.props.selectedItem} selectItem={_this.props.selectItem} />
-        </div>
-      )
+      return <GalleryRow key={index} row={row} selectedItem={_this.props.selectedItem} selectItem={_this.props.selectItem} />;
     });
 
     return (

--- a/resources/assets/js/components/Gallery.js
+++ b/resources/assets/js/components/Gallery.js
@@ -1,6 +1,6 @@
 import React from 'react/addons';
 import classNames from 'classnames';
-import { chunk } from 'lodash';
+import chunk from 'lodash/array/chunk';
 
 import GalleryRow from './GalleryRow';
 

--- a/resources/assets/js/components/Gallery.js
+++ b/resources/assets/js/components/Gallery.js
@@ -21,6 +21,7 @@ class Gallery extends React.Component {
    * @returns {number}
    */
   tilesPerRow() {
+    // Assume a desktop view for pre-rendering on the server
     if(typeof window === 'undefined') return 4;
 
     if(window.innerWidth > 1100) {

--- a/resources/assets/js/components/Gallery.js
+++ b/resources/assets/js/components/Gallery.js
@@ -61,10 +61,10 @@ class Gallery extends React.Component {
     // Show "empty state" if no items
     if(this.props.items.length === 0) {
       return (
-        <div className="gallery -empty">
-          <div className="gallery__empty">No matches!</div>
+        <div className="gallery">
+          <div className="empty">No matches!</div>
         </div>
-      )
+      );
     }
 
     const chunkedItems = chunk(this.props.items, this.state.itemsPerRow);
@@ -73,11 +73,23 @@ class Gallery extends React.Component {
       return <GalleryRow key={index} row={row} selectedItem={_this.props.selectedItem} selectItem={_this.props.selectItem} />;
     });
 
+    let heading;
+    if(this.props.name) {
+      heading = <h2 className='gallery__heading'>{this.props.name}</h2>;
+    }
+
     return (
-      <div className='gallery'>{rows}</div>
+      <div className='gallery'>
+        {heading}
+        {rows}
+      </div>
     );
   }
 
 }
+
+Gallery.defaultProps = {
+  items: []
+};
 
 export default Gallery;

--- a/resources/assets/js/components/GalleryRow.js
+++ b/resources/assets/js/components/GalleryRow.js
@@ -1,0 +1,41 @@
+import React from 'react/addons';
+
+import Tile from './Tile';
+import Drawer from './Drawer';
+
+class GalleryRow extends React.Component {
+
+  /**
+   * Render component.
+   * @returns {XML}
+   */
+  render() {
+    const _this = this;
+
+    // Build each tile in the row
+    let hasSelectedTile = false;
+    var tiles = this.props.row.map(function(candidate) {
+      const selected = candidate === _this.props.selectedItem;
+      if(selected) {
+        hasSelectedTile = selected;
+      }
+
+      return (
+        <li key={candidate.id} className='gallery__item'>
+          <Tile candidate={candidate} selected={selected} onClick={_this.props.selectItem} />
+        </li>
+      );
+    });
+
+    // Return the row
+    return (
+      <div>
+        {tiles}
+        <Drawer isOpen={hasSelectedTile} candidate={_this.props.selectedItem} selectItem={_this.props.selectItem} />
+      </div>
+    )
+  }
+
+}
+
+export default GalleryRow;

--- a/resources/assets/js/components/SearchForm.js
+++ b/resources/assets/js/components/SearchForm.js
@@ -2,13 +2,22 @@ import React from 'react/addons';
 
 class SearchForm extends React.Component {
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      query: props.query || ''
+    };
+
+    this.onChange = this.onChange.bind(this);
+  }
+
   /**
    * Send search query to parent component on text input.
    * @param event
    */
   onChange(event) {
     event.preventDefault();
-
     this.props.onChange(event.target.value);
   }
 
@@ -18,9 +27,9 @@ class SearchForm extends React.Component {
    */
   render() {
     return (
-      <div className='search-form'>
-        <input type="search" placeholder='Find a candidate...' onChange={this.onChange.bind(this)} />
-      </div>
+      <form method='GET' action='/candidates' className='search-form' onSubmit={this.onChange}>
+        <input type='search' name='query' id='query' value={this.props.query} placeholder='Find a candidate...' onChange={this.onChange} />
+      </form>
     );
   }
 

--- a/resources/assets/js/components/Tile.js
+++ b/resources/assets/js/components/Tile.js
@@ -1,5 +1,6 @@
 import React from 'react/addons';
 import classNames from 'classnames';
+import shallowCompare from '../vendor/shallowCompare';
 
 class Tile extends React.Component {
 
@@ -18,6 +19,21 @@ class Tile extends React.Component {
     this.props.onClick(this);
   }
 
+
+  /**
+   * Only re-render this component if props or state change.
+   * @param nextProps
+   * @param nextState
+   * @returns {boolean}
+   */
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  }
+
+  /**
+   * Render component.
+   * @returns {XML}
+   */
   render() {
     let candidate = this.props.candidate;
 

--- a/resources/assets/js/server.js
+++ b/resources/assets/js/server.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import express from 'express';
+import bodyParser from 'body-parser';
+import path from 'path';
+
+/**
+ * Set up Express.
+ */
+const app = express();
+app.use(bodyParser.json());
+
+/**
+ * Simple error handler.
+ */
+app.use(function(err, req, res, next) {
+  console.error(err.stack);
+  res.status(500).send('Something broke!');
+});
+
+app.use('/:component', function(request, response) {
+  const component = require(path.resolve('./resources/assets/js/components/' + request.params.component));
+  const props = request.body || null;
+
+  response.status(200).send(
+    React.renderToString(
+      React.createElement(component, props)
+    )
+  );
+});
+
+export default app;
+

--- a/resources/assets/js/utilities/rehydrate.js
+++ b/resources/assets/js/utilities/rehydrate.js
@@ -1,0 +1,23 @@
+import React from 'react/addons';
+
+/**
+ * Re-hydrate any rendered React components
+ */
+function rehydrate(components) {
+
+  // Get all React pre-rendered elements by data-attribute
+  const reactElements = document.querySelectorAll('*[data-rendered-component]');
+
+  // Rehydrate each component
+  Array.prototype.forEach.call(reactElements, function(el) {
+    const id = el.getAttribute('id');
+    const props = JSON.parse(document.getElementById(`${id}-props`).innerHTML);
+
+    const component = el.getAttribute('data-rendered-component');
+    if(components[component]) {
+      React.render(React.createElement(components[component], props), el);
+    }
+  });
+}
+
+export default rehydrate;

--- a/resources/assets/js/vendor/shallowCompare.js
+++ b/resources/assets/js/vendor/shallowCompare.js
@@ -1,0 +1,56 @@
+/**
+ * Performs equality by iterating through keys on an object and returning
+ * false when any key has values which are not strictly equal between
+ * objA and objB. Returns true when the values of all keys are strictly equal.
+ *
+ * @see https://github.com/facebook/react/blob/master/src/shared/utils/shallowEqual.js
+ *
+ * @return {boolean}
+ */
+function shallowEqual(objA, objB) {
+  if (objA === objB) {
+    return true;
+  }
+
+  if (typeof objA !== 'object' || objA === null ||
+    typeof objB !== 'object' || objB === null) {
+    return false;
+  }
+
+  var keysA = Object.keys(objA);
+  var keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  // Test for A's keys different from B.
+  var bHasOwnProperty = Object.prototype.hasOwnProperty.bind(objB);
+  for (var i = 0; i < keysA.length; i++) {
+    if (!bHasOwnProperty(keysA[i]) || objA[keysA[i]] !== objB[keysA[i]]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Does a shallow comparison for props and state, like in React's
+ * PureRenderMixin, but compatible with ES6 classes.
+ *
+ * @TODO: Will be added to React Addons in a future release, see below.
+ * https://github.com/facebook/react/blob/master/src/addons/shallowCompare.js
+ *
+ * @param instance
+ * @param nextProps
+ * @param nextState
+ */
+function shallowCompare(instance, nextProps, nextState) {
+  return (
+    !shallowEqual(instance.props, nextProps) ||
+    !shallowEqual(instance.state, nextState)
+  );
+}
+
+export default shallowCompare;

--- a/resources/assets/sass/components/_empty.scss
+++ b/resources/assets/sass/components/_empty.scss
@@ -1,12 +1,9 @@
 // Empty state placeholder
-
-.gallery {
-  .empty {
-    width: 100%;
-    padding: $base-spacing * 4;
-    color: $gray;
-    font-size: $medium-font-size;
-    text-align: center;
-    border: 2px dashed $gray;
-  }
+.empty {
+  width: 100%;
+  padding: $base-spacing * 4;
+  color: $gray;
+  font-size: $medium-font-size;
+  text-align: center;
+  border: 2px dashed $gray;
 }

--- a/resources/assets/sass/components/_form.scss
+++ b/resources/assets/sass/components/_form.scss
@@ -22,6 +22,9 @@ input[type="month"], input[type="time"], input[type="week"], textarea {
   padding: ($base-spacing / 2);
   margin-bottom: $base-spacing;
 
+  -moz-appearance: none;
+  -webkit-appearance: none;
+
   &:focus {
     border: 1px solid $cyan;
     outline: none;

--- a/resources/assets/sass/components/_search-form.scss
+++ b/resources/assets/sass/components/_search-form.scss
@@ -1,15 +1,22 @@
 .search-form {
-  @include span(9);
   @include clearfix;
   position: relative;
 
+  @include media('medium') {
+    @include span(8);
+  }
+
+  @include media('large') {
+    @include span(9);
+  }
+
   input[type='search'] {
+    box-sizing: border-box;
     width: 100%;
+    color: #fff;
+    border: rgba(#222, 0.8);
     background: rgba(#222, 0.8) data-url($data-search-white-svg) ($base-spacing / 2) 48% no-repeat;
     background-size: $base-spacing $base-spacing;
-    border: rgba(#222, 0.8);
-    color: #fff;
-    padding-left: 48px;
-    box-sizing: border-box;
+    padding-left: ($base-spacing * 2);
   }
 }

--- a/resources/assets/sass/modules/_drawer.scss
+++ b/resources/assets/sass/modules/_drawer.scss
@@ -12,7 +12,7 @@
     &.drawer-animation-enter-active {
       opacity: 1;
       max-height: 800px;
-      transition: opacity 0.5s, max-height 0.5s;
+      transition: opacity 0.5s ease-out, max-height 0.5s ease-out;
     }
   }
 
@@ -23,7 +23,7 @@
     &.drawer-animation-leave-active {
       max-height: 0;
       opacity: 0;
-      transition: opacity 0.5s, max-height 0.5s;
+      transition: opacity 0.5s ease-out, max-height 0.5s ease-out;
     }
   }
 

--- a/resources/assets/sass/modules/_drawer.scss
+++ b/resources/assets/sass/modules/_drawer.scss
@@ -6,24 +6,24 @@
   // Animation via ReactCSSTransitionGroup
   // @see: https://facebook.github.io/react/docs/animation.html
   &.drawer-animation-enter {
-    transition: opacity 0.5s, max-height 0.5s;
     max-height: 0;
     opacity: 0;
 
     &.drawer-animation-enter-active {
       opacity: 1;
       max-height: 800px;
+      transition: opacity 0.5s, max-height 0.5s;
     }
   }
 
   &.drawer-animation-leave {
-    transition: opacity 0.5s, max-height 0.5s;
     opacity: 1;
     max-height: 800px;
 
     &.drawer-animation-leave-active {
       max-height: 0;
       opacity: 0;
+      transition: opacity 0.5s, max-height 0.5s;
     }
   }
 

--- a/resources/assets/sass/modules/_gallery.scss
+++ b/resources/assets/sass/modules/_gallery.scss
@@ -7,10 +7,9 @@
   margin: $base-spacing 0;
   padding: 0;
 
-  &.-empty {
-    margin: 0 0 ($base-spacing * 2);
+  .gallery__heading {
+    padding: 0 gutter() $base-spacing;
   }
-
 
   .gallery__row {
     @include clearfix;
@@ -27,16 +26,4 @@
       @include span(3);
     }
   }
-
-  .gallery__empty {
-    @include span(100%);
-    color: $gray;
-    font-size: $base-font-size;
-    padding-top: ($base-spacing / 2);
-  }
-}
-
-// Oh, shush.
-.gallery-heading {
-  padding: 0 gutter();
 }

--- a/resources/assets/sass/regions/_candidate.scss
+++ b/resources/assets/sass/regions/_candidate.scss
@@ -41,7 +41,11 @@
   }
 
   .candidate__description {
-    padding: $base-spacing;
+    padding-bottom: $base-spacing;
+
+    @include media('medium') {
+      padding: $base-spacing;
+    }
   }
 
   .candidate__actions {

--- a/resources/views/candidates/index.blade.php
+++ b/resources/views/candidates/index.blade.php
@@ -2,7 +2,8 @@
 
 @section('content')
     @if($categories)
-        {!! $gallery !!}
+
+        @react('CandidateIndex', compact('categories', 'query'))
 
         <div class="wrapper -narrow">
             <h4>Was there a {{ setting('candidate_type') }} we missed?</h4>

--- a/resources/views/candidates/index.blade.php
+++ b/resources/views/candidates/index.blade.php
@@ -2,27 +2,7 @@
 
 @section('content')
     @if($categories)
-        <div id="gallery">
-            @forelse($categories as $category)
-                <h2 class="gallery-heading">{{ $category->name }}</h2>
-
-                <ul class="gallery">
-                    @if($category->candidates)
-                        @foreach($category->candidates as $candidate)
-                            @include('candidates.partials.tile', ['candidate' => $candidate, 'drawer' => true])
-                        @endforeach
-                    @else
-                        <li class="empty">No candidates in this category... yet!</li>
-                    @endif
-                </ul>
-            @empty
-                <div class="empty">No categories... yet!</div>
-            @endforelse
-
-            <script type="application/json" id="gallery-json">
-                {!! $categories->toJson() !!}
-            </script>
-        </div>
+        {!! $gallery !!}
 
         <div class="wrapper -narrow">
             <h4>Was there a {{ setting('candidate_type') }} we missed?</h4>

--- a/resources/views/categories/show.blade.php
+++ b/resources/views/categories/show.blade.php
@@ -3,31 +3,12 @@
 @section('title', $category->name)
 
 @section('content')
-    {{-- If there are winners, put them first. --}}
-    <ul class="gallery">
-        @if($winners)
-            @foreach($winners as $winner)
-                @include('winners.tile', ['winner' => $winner, 'drawer' => true])
-            @endforeach
-        @endif
-    </ul>
-
     @if(setting('show_candidates'))
         @if($winners)
             <h1 class="highlighted gallery-heading">All Nominees</h1>
         @endif
 
-        <h2 class="gallery-heading">{{ $category->name }}</h2>
-
-        <ul class="gallery">
-            @if($category->candidates)
-                @foreach($category->candidates as $candidate)
-                    @include('candidates.partials.tile', ['candidate' => $candidate, 'drawer' => true])
-                @endforeach
-            @else
-                <li class="empty">No candidates in this category... yet!</li>
-            @endif
-        </ul>
+        {!! $gallery !!}
 
         <div class="wrapper -narrow">
             <p class="messages -inline">Want to see more candidates? <a href="{{ route('home') }}">View all</a></p>
@@ -48,5 +29,5 @@
         </script>
     @endif
 
-    @include('users.partials.closed');
+    @include('users.partials.closed')
 @stop

--- a/resources/views/categories/show.blade.php
+++ b/resources/views/categories/show.blade.php
@@ -1,6 +1,6 @@
 @extends('app')
 
-@section('title', $category->name)
+@section('title', $name)
 
 @section('content')
     @if(setting('show_candidates'))
@@ -8,7 +8,7 @@
             <h1 class="highlighted gallery-heading">All Nominees</h1>
         @endif
 
-        {!! $gallery !!}
+        @react('CategoryIndex', compact('name', 'candidates'))
 
         <div class="wrapper -narrow">
             <p class="messages -inline">Want to see more candidates? <a href="{{ route('home') }}">View all</a></p>


### PR DESCRIPTION
# Changes

This PR adds adds a little Node service to pre-render React views on the server. This allows the application to gracefully degrade into a standard server-rendered application if either JavaScript is unavailable or the user's browser doesn't [cut the mustard](https://github.com/DoSomething/voting-app/blob/dev/resources/assets/js/utilities/mustard.js) (i.e. Internet Explorer 8).

References #347.
/cc @mshmsh5000 @blisteringherb 
# Next Steps

This introduces another runtime dependency for the application, so we'll need to update servers to run the included `bootstrap/react_server.js` Node application, and update installation instructions to ensure it is running when doing local development.

It might also make sense to look into adding a caching layer for the React renderer, ~~and pre-compiling ES6 to ES5 rather than using the require hook~~, depending on how this works under load.

**Update:** Did some further research and the Babel require hook caches after the initial compilation step, so there shouldn't be any real performance impact there.
