### PR TITLE
Add first name to Message Broker payload.

### DIFF
--- a/app/Handlers/Events/SendFirstVoteMessage.php
+++ b/app/Handlers/Events/SendFirstVoteMessage.php
@@ -27,6 +27,7 @@ class SendFirstVoteMessage
 
         $payload = [
             // User information
+            'first_name' => $event->user->first_name,
             'birthdate_timestamp' => strtotime($event->user->birthdate), // Message Broker expects UNIX timestamp
             'country_code' => $event->user->country_code,
 


### PR DESCRIPTION
# Changes

First name was being included as an email merge var, but missing from mobile payload. This adds `first_name` to the standard payload sent for both email & mobile messages.

For review: @DeeZone 
