### PR TITLE
Fix container being pushed off page in Firefox. Closes #353.

### DIFF
--- a/resources/assets/sass/regions/_container.scss
+++ b/resources/assets/sass/regions/_container.scss
@@ -2,6 +2,7 @@
 
 .container {
   @include clearfix;
+  clear: both;
 
   .row {
     margin-bottom: $base-spacing * 4;


### PR DESCRIPTION
# Changes

Fix issue where the `.container` class was being pushed off page in Firefox. Closes #353.

For review: @DoSomething/front-end 
