### PR TITLE
Ensure mutators run before validating database uniqueness.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -1,6 +1,7 @@
 <?php namespace VotingApp\Exceptions;
 
 use Exception;
+use Illuminate\Contracts\Validation\ValidationException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 
 class Handler extends ExceptionHandler
@@ -37,6 +38,10 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $e)
     {
+        if($e instanceof ValidationException) {
+            return redirect()->back()->withErrors($e->errors());
+        }
+
         return parent::render($request, $e);
     }
 }


### PR DESCRIPTION
# Changes
- Fixes #362 by ensuring model mutators are run before validating database uniqueness.
- Adds global and vote-specific (for proper redirection) handling of `ValidationException` so that we can trigger validation errors from within services, rather than only in the controller.

For review: @angaither 
