### PR TITLE
Close software keyboards when user hits 'Search' on mobile.

### DIFF
--- a/resources/assets/js/components/SearchForm.js
+++ b/resources/assets/js/components/SearchForm.js
@@ -22,13 +22,26 @@ class SearchForm extends React.Component {
   }
 
   /**
+   * If enter key is pressed, blur the field to close
+   * keyboard on touch devices.
+   * @param event
+   */
+  onKeyDown(event) {
+    if(event.keyCode === 13) {
+      event.preventDefault();
+      document.activeElement.blur();
+    }
+  }
+
+  /**
    * Render component.
    * @returns {XML}
    */
   render() {
     return (
       <form method='GET' action='/candidates' className='search-form' onSubmit={this.onChange}>
-        <input type='search' name='query' id='query' value={this.props.query} placeholder='Find a candidate...' onChange={this.onChange} />
+        <input type='search' name='query' id='query' value={this.props.query} placeholder='Find a candidate...'
+          onChange={this.onChange} onKeyDown={this.onKeyDown} />
       </form>
     );
   }


### PR DESCRIPTION
# Changes

I noticed that the keyboard never dismisses when searching for a candidate on a mobile device, so this fixes that. When the user hits "Search" or "Submit" on the software keyboard, this blurs the input field so the keyboard will dismiss.

For review: @DoSomething/front-end 
