### PR TITLE
Fix scrolling wonkiness

### DIFF
--- a/resources/assets/js/components/CandidateIndex.js
+++ b/resources/assets/js/components/CandidateIndex.js
@@ -34,7 +34,10 @@ class CandidateIndex extends React.Component {
    * @param query
    */
   setQuery(query) {
-    this.setState({ query: query });
+    this.setState({
+      query: query,
+      selectedItem: null
+    });
   }
 
   /**

--- a/resources/assets/js/components/CategoryIndex.js
+++ b/resources/assets/js/components/CategoryIndex.js
@@ -6,8 +6,16 @@ class CategoryIndex extends React.Component {
   constructor(props) {
     super(props);
 
+    // Assign incremental key to candidates
+    let i = 1;
+    const candidates = props.candidates.map(function(candidate) {
+      candidate.key = i++;
+      return candidate;
+    });
+
     this.state = {
-      selectedItem: null
+      selectedItem: null,
+      candidates: candidates
     };
 
     this.selectItem = this.selectItem.bind(this);
@@ -15,7 +23,7 @@ class CategoryIndex extends React.Component {
 
   /**
    * Set or unset the selected item to show details for.
-   * @param query
+   * @param item
    */
   selectItem(item) {
     // De-select if trying to select the same item again.
@@ -33,10 +41,7 @@ class CategoryIndex extends React.Component {
    */
   render() {
     return (
-      <div className='category'>
-        <h2 className='gallery-heading'>{this.props.name}</h2>
-        <Gallery items={this.props.candidates} selectItem={this.selectItem} selectedItem={this.state.selectedItem} />
-      </div>
+      <Gallery name={this.props.name} items={this.props.candidates} selectItem={this.selectItem} selectedItem={this.state.selectedItem} />
     );
   }
 


### PR DESCRIPTION
# Changes

Fixes #378. Leaving the drawer open when filtering candidates was causing some wonky scrolling issues, and also potentially "hid" users if a drawer was open after the first row of results and a user did not think to scroll past it. We fix both those issues by de-selecting any gallery elements whenever the search query is updated.

For review: @DoSomething/front-end  
