### PR TITLE
Set history on search with HTML5 History API.

### DIFF
--- a/app/Http/Controllers/CandidatesController.php
+++ b/app/Http/Controllers/CandidatesController.php
@@ -50,8 +50,9 @@ class CandidatesController extends Controller
 
         $query = $request->get('query', '');
         $categories = Category::with('candidates')->get();
+        $title = setting('site_title');
 
-        return view('candidates.index', compact('categories', 'query'));
+        return view('candidates.index', compact('categories', 'query', 'title'));
     }
 
     /**

--- a/resources/assets/js/components/CandidateIndex.js
+++ b/resources/assets/js/components/CandidateIndex.js
@@ -8,6 +8,23 @@ class CandidateIndex extends React.Component {
   constructor(props) {
     super(props);
 
+    this.state = this.initialState(props);
+
+    this.selectItem = this.selectItem.bind(this);
+    this.setQuery = this.setQuery.bind(this);
+
+    // Set HTML5 history event listener
+    if(typeof window !== 'undefined') {
+      window.addEventListener('popstate', (event) => this.setState(event.state || this.initialState()));
+    }
+  }
+
+  /**
+   * Function which returns initial state of this component.
+   * @param props
+   * @returns object
+   */
+  initialState(props = this.props) {
     // Assign incremental key to candidates
     let i = 1;
     const categories = props.categories.map(function(category) {
@@ -19,30 +36,33 @@ class CandidateIndex extends React.Component {
       return category;
     });
 
-    this.state = {
+    return {
       query: props.query || '',
       selectedItem: null,
       categories: categories
-    };
-
-    this.selectItem = this.selectItem.bind(this);
-    this.setQuery = this.setQuery.bind(this);
+    }
   }
 
   /**
    * Set the query to filter galleries by.
-   * @param query
+   * @param query - Search query
+   * @param save - Should query be persisted in browser history?
    */
-  setQuery(query) {
+  setQuery(query, save = false) {
     this.setState({
       query: query,
       selectedItem: null
     });
+
+    if(save) {
+      const url = `${location.protocol}//${location.host}${location.pathname}?query=${encodeURIComponent(query)}`;
+      history.pushState(this.state, document.title, url);
+    }
   }
 
   /**
    * Set or unset the selected item to show details for.
-   * @param query
+   * @param item
    */
   selectItem(item) {
     // De-select if trying to select the same item again.
@@ -100,5 +120,9 @@ class CandidateIndex extends React.Component {
   }
 
 }
+
+CandidateIndex.defaultProps = {
+  title: 'Voting App'
+};
 
 export default CandidateIndex;

--- a/resources/assets/js/components/SearchForm.js
+++ b/resources/assets/js/components/SearchForm.js
@@ -10,6 +10,8 @@ class SearchForm extends React.Component {
     };
 
     this.onChange = this.onChange.bind(this);
+    this.onKeyDown = this.onKeyDown.bind(this);
+    this.onBlur = this.onBlur.bind(this);
   }
 
   /**
@@ -34,6 +36,14 @@ class SearchForm extends React.Component {
   }
 
   /**
+   * Persist the search query when user blurs the text field.
+   * @param event
+   */
+  onBlur(event) {
+    this.props.onChange(event.target.value, true);
+  }
+
+  /**
    * Render component.
    * @returns {XML}
    */
@@ -41,7 +51,7 @@ class SearchForm extends React.Component {
     return (
       <form method='GET' action='/candidates' className='search-form' onSubmit={this.onChange}>
         <input type='search' name='query' id='query' value={this.props.query} placeholder='Find a candidate...'
-          onChange={this.onChange} onKeyDown={this.onKeyDown} />
+          onChange={this.onChange} onKeyDown={this.onKeyDown} onBlur={this.onBlur} />
       </form>
     );
   }


### PR DESCRIPTION
# Changes
- Save current search query in URL with the [HTML5 History API](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history#Adding_and_modifying_history_entries), so that users (or campaign leads) can easily link to a particular search page. This extends the fallback added in #348.  :hourglass: 
- This also lets users hit the "Back" button to return to their previous results if they searched for something and didn't see what they were looking for. Nice! :rewind: 

For review: @DoSomething/front-end 
