### PR TITLE
Fix react server-side renderer

### DIFF
--- a/resources/assets/js/server.js
+++ b/resources/assets/js/server.js
@@ -18,7 +18,7 @@ app.use(function(err, req, res, next) {
 });
 
 app.use('/:component', function(request, response) {
-  const component = require(path.resolve('./resources/assets/js/components/' + request.params.component));
+  const component = require(`./components/${request.params.component}`);
   const props = request.body || null;
 
   response.status(200).send(


### PR DESCRIPTION
# Changes
- The server-side renderer was failing if it wasn't called from the application root. Fixed by using relative path from `server.js` to the `components/` folder instead.

For review: @DoSomething/front-end 
