### PR TITLE
Remove Handlebars transform from dependencies.

### DIFF
--- a/app/Http/Controllers/CandidatesController.php
+++ b/app/Http/Controllers/CandidatesController.php
@@ -2,7 +2,6 @@
 
 use VotingApp\Models\Candidate;
 use VotingApp\Models\Category;
-use VotingApp\Services\ReactService;
 use Illuminate\Http\Request;
 use Auth;
 use DB;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "browserify-handlebars": "^1.0.0",
     "gulp": "^3.8.8",
     "laravel-elixir": "1.0.1"
   },


### PR DESCRIPTION
# Changes

Remove `browserify-handlebars` transform, since we're building client side interfaces with React now & this is no longer being used. Also removes an unused `use` reference to the React service.

For review: @DoSomething/front-end 
