### PR TITLE
Update write-in email setting to accept any link URL.

### DIFF
--- a/database/migrations/2015_06_30_182529_add_writein_link_to_settings.php
+++ b/database/migrations/2015_06_30_182529_add_writein_link_to_settings.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddWriteinLinkToSettings extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+        DB::table('settings')
+            ->where('key', 'writein_email')
+            ->update([
+                'key' => 'writein_link',
+                'description' => 'Link provided for write-in candidates.',
+            ]);
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+        DB::table('settings')
+            ->where('key', 'writein_link')
+            ->update([
+                'key' => 'writein_email',
+                'description' => 'Email provided for write-in candidates.',
+            ]);
+	}
+
+}

--- a/resources/assets/sass/regions/_container.scss
+++ b/resources/assets/sass/regions/_container.scss
@@ -18,8 +18,8 @@
       &.-narrow {
         text-align: center;
 
-        @include span(6);
-        @include pre(3);
+        @include span(4);
+        @include pre(4);
       }
     }
   }

--- a/resources/views/candidates/index.blade.php
+++ b/resources/views/candidates/index.blade.php
@@ -10,8 +10,7 @@
 
             <p>
                 If you know a {{ setting('candidate_type') }} who's done kickass things in the world, but don't see them
-                on our list, let us know by emailing <a href="mailto:{{ setting('writein_email') }}">{{ setting('writein_email') }}</a>.
-                Make sure to include the work they've done in the past year for social good (in 140 characters or less). Thank you!
+                on our list, <a href="{{ setting('writein_link') }}">let us know</a>.
             </p>
         </div>
 

--- a/resources/views/categories/show.blade.php
+++ b/resources/views/categories/show.blade.php
@@ -19,8 +19,7 @@
 
             <p>
                 If you know a {{ setting('candidate_type') }} who's done kickass things in the world, but don't see them
-                on our list, let us know by emailing <a href="mailto:{{ setting('writein_email') }}">{{ setting('writein_email') }}</a>.
-                Make sure to include the work they've done in the past year for social good (in 140 characters or less). Thank you!
+                on our list, <a href="{{ setting('writein_link') }}">let us know</a>.
             </p>
         </div>
 


### PR DESCRIPTION
# Changes

Fixes #395. Write-in form can now link to an email address (with value `mailto:email@example.com`) or any URL such as a Google Docs form. :page_with_curl: 

For review: @angaither 
