### PR TITLE
Add setting to control language used when sharing from footer.

### DIFF
--- a/database/migrations/2015_07_01_152623_add_twitter_site_language_to_settings.php
+++ b/database/migrations/2015_07_01_152623_add_twitter_site_language_to_settings.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddTwitterSiteLanguageToSettings extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+        DB::table('settings')->insert([
+            'key' => 'twitter_site_language',
+            'type' => 'text',
+            'value' => '.@dosomething\'s #VotingApp is back. Vote now:',
+            'description' => 'Language used when sharing the site on Twitter.'
+        ]);
+    }
+
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::table('settings')->delete(['key' => 'twitter_site_language']);
+	}
+
+}

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -6,7 +6,7 @@
         <li><a class="social-icon -facebook js-share-link" href="{{ facebook_intent(url('/')) }}"><span>Facebook</span></a>
         </li>
         <li><a class="social-icon -twitter js-share-link"
-               href="{{ tweet_intent('.@dosomething\'s #CelebsGoneGood is back, vote for your fav celeb doing kickass things in the world this year now: ', url('/')) }}"><span>Twitter</span></a>
+               href="{{ tweet_intent(setting('twitter_site_language'), url('/')) }}"><span>Twitter</span></a>
         </li>
     </ul>
 </footer>


### PR DESCRIPTION
# Changes

Twitter language when clicking the icon in the footer was still sharing #CelebsGoneGood. This makes that customizable by site administrators.

For review: @angaither 
