### PR TITLE
Performance improvements

### DIFF
--- a/app/Http/Controllers/CandidatesController.php
+++ b/app/Http/Controllers/CandidatesController.php
@@ -48,10 +48,11 @@ class CandidatesController extends Controller
         }
 
         $query = $request->get('query', '');
+        $limit = $request->get('limit', '16');
         $categories = Category::orderBy('name', 'asc')->with('candidates')->get();
         $title = setting('site_title');
 
-        return view('candidates.index', compact('categories', 'query', 'title'));
+        return view('candidates.index', compact('categories', 'query', 'limit', 'title'));
     }
 
     /**

--- a/resources/assets/js/components/AlternateTile.js
+++ b/resources/assets/js/components/AlternateTile.js
@@ -1,0 +1,35 @@
+import React from 'react/addons';
+import shallowCompare from '../vendor/shallowCompare';
+
+class AlternateTile extends React.Component {
+
+  /**
+   * Only re-render this component if props or state change.
+   * @param nextProps
+   * @param nextState
+   * @returns {boolean}
+   */
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  }
+
+  /**
+   * Render component.
+   * @returns {XML}
+   */
+  render() {
+    return (
+      <article className='tile -alternate'>
+        <div className='wrapper'>
+          <div className='tile__meta'>
+            <h1>{this.props.candidate.name}</h1>
+          </div>
+          <img alt={this.props.candidate.name} src={this.props.candidate.thumbnail} />
+        </div>
+      </article>
+    );
+  }
+
+}
+
+export default AlternateTile;

--- a/resources/assets/js/components/CandidateDetailView.js
+++ b/resources/assets/js/components/CandidateDetailView.js
@@ -1,5 +1,5 @@
 import React from 'react/addons';
-import Tile from './Tile';
+import AlternateTile from './AlternateTile';
 
 class CandidateDetailView extends React.Component {
 
@@ -34,7 +34,7 @@ class CandidateDetailView extends React.Component {
       <div className='candidate'>
         <div className='wrapper'>
           <div className="candidate__info">
-            <Tile candidate={this.props.candidate} alternate={true}/>
+            <AlternateTile candidate={this.props.candidate} />
             <p className="candidate__description">{this.props.candidate.description}</p>
           </div>
 

--- a/resources/assets/js/components/CandidateIndex.js
+++ b/resources/assets/js/components/CandidateIndex.js
@@ -59,12 +59,12 @@ class CandidateIndex extends React.Component {
 
   handleInfiniteScroll() {
     const paginator = document.getElementById('pagination');
+    const offset = 500;
 
     if(paginator) {
-      const scrollY = window.scrollY;
-      const endOfPage = getOffset(paginator);
+      const endOfPage = getOffset(paginator) - offset;
 
-      if ((scrollY + window.innerHeight) > endOfPage) {
+      if ((window.scrollY + window.innerHeight) > endOfPage) {
         this.setState({ limit: this.state.limit + 25 });
       }
     }

--- a/resources/assets/js/components/CandidateIndex.js
+++ b/resources/assets/js/components/CandidateIndex.js
@@ -43,7 +43,7 @@ class CandidateIndex extends React.Component {
 
     return {
       query: props.query || '',
-      limit: props.limit,
+      limit: parseInt(props.limit),
       totalItemCount: count,
       selectedItem: null,
       categories: categories
@@ -148,7 +148,7 @@ class CandidateIndex extends React.Component {
       <div>
         <SearchForm onChange={this.setQuery} query={this.state.query} />
         {galleries.length ? galleries : <Gallery />}
-        {shouldShowPagination ? <a className='pagination-link' href={`?limit=${this.state.limit + 25}`} onClick={this.showMore}>Show More</a> : null }
+        {shouldShowPagination ? <a id='pagination' className='pagination-link' href={`?limit=${this.state.limit + 25}#pagination`} onClick={this.showMore}>Show More</a> : null }
       </div>
     );
   }

--- a/resources/assets/js/components/CandidateIndex.js
+++ b/resources/assets/js/components/CandidateIndex.js
@@ -9,9 +9,12 @@ class CandidateIndex extends React.Component {
   constructor(props) {
     super(props);
 
+    this.totalItemsCount = 0;
+
     this.state = this.initialState(props);
 
     this.selectItem = this.selectItem.bind(this);
+    this.showMore = this.showMore.bind(this);
     this.setQuery = this.setQuery.bind(this);
     this.setQuery = debounce(this.setQuery, 20, { leading: true });
 
@@ -28,10 +31,10 @@ class CandidateIndex extends React.Component {
    */
   initialState(props = this.props) {
     // Assign incremental key to candidates
-    let i = 1;
+    let count = 1;
     const categories = props.categories.map(function(category) {
       category.candidates.map(function(candidate) {
-        candidate.key = i++;
+        candidate.key = count++;
         return candidate;
       });
 
@@ -40,9 +43,20 @@ class CandidateIndex extends React.Component {
 
     return {
       query: props.query || '',
+      limit: props.limit,
+      totalItemCount: count,
       selectedItem: null,
       categories: categories
     }
+  }
+
+  /**
+   * Increase number of tiles shown as user scrolls.
+   */
+  showMore(event) {
+    event.preventDefault();
+
+    this.setState({ limit: this.state.limit + 25 });
   }
 
   /**
@@ -53,7 +67,8 @@ class CandidateIndex extends React.Component {
   setQuery(query, save = false) {
     this.setState({
       query: query,
-      selectedItem: null
+      selectedItem: null,
+      limit: this.props.limit
     });
 
     if(save) {
@@ -78,21 +93,41 @@ class CandidateIndex extends React.Component {
 
   /**
    * Filter candidates by the current search query.
-   * @param candidates - Object containing candidates to be filtered
-   * @param categoryName - Category name
-   * @returns object - Filtered candidates
+   * @returns {object} - Filtered candidates
    */
-  filteredCandidates(candidates, categoryName) {
-    const query = this.state.query.toUpperCase();
-    categoryName = categoryName.toUpperCase();
+  filteredCandidates() {
+    let count = 0;
+    let categories = this.props.categories.map((category) => {
+      const query = this.state.query.toUpperCase();
+      const categoryName = category.name.toUpperCase();
 
-    if(query === '') return candidates;
+      const filteredCandidates = category.candidates.filter((candidate) => {
+        const name = candidate.name.toUpperCase();
 
-    // Filter candidates by search query...
-    return candidates.filter(function(candidate) {
-      const name = candidate.name.toUpperCase();
-      return (includes(name, query) || includes(categoryName, query) ? candidate : null);
+        // Only include candidates up until the given limit
+        if (count > this.state.limit) return null;
+
+        if (includes(name, query) || includes(categoryName, query) || query === '') {
+          count++;
+          return candidate;
+        }
+      });
+
+
+      // Filter candidates by search query...
+      return {
+        id: category.id,
+        name: category.name,
+        candidates: filteredCandidates
+      }
     });
+
+    // Finally, remove any any empty categories from the array
+    categories = categories.filter(function(category) { return category.candidates && category.candidates.length !== 0 });
+
+    console.log(count);
+
+    return { count, categories };
   }
 
   /**
@@ -100,23 +135,20 @@ class CandidateIndex extends React.Component {
    * @returns {XML}
    */
   render() {
-    var _this = this;
-    var galleries = this.state.categories.map(function(category) {
-      var candidates = _this.filteredCandidates(category.candidates, category.name);
-      if(candidates.length == 0) return;
+    const filtered = this.filteredCandidates();
 
-      return (
-        <Gallery key={category.id} name={category.name} items={candidates} selectItem={_this.selectItem} selectedItem={_this.state.selectedItem} />
-      );
+    let galleries = filtered.categories.map((category) => {
+      return <Gallery key={category.id} name={category.name} items={category.candidates} selectItem={this.selectItem} selectedItem={this.state.selectedItem} />;
     });
 
-    // Remove any null entries from the array
-    galleries = galleries.filter(function(gallery) { return typeof gallery != 'undefined' });
+    const shouldShowPagination = this.state.limit < filtered.count;
+    console.log(shouldShowPagination);
 
     return (
       <div>
         <SearchForm onChange={this.setQuery} query={this.state.query} />
         {galleries.length ? galleries : <Gallery />}
+        {shouldShowPagination ? <a className='pagination-link' href={`?limit=${this.state.limit + 25}`} onClick={this.showMore}>Show More</a> : null }
       </div>
     );
   }
@@ -124,7 +156,8 @@ class CandidateIndex extends React.Component {
 }
 
 CandidateIndex.defaultProps = {
-  title: 'Voting App'
+  title: 'Voting App',
+  limit: 16
 };
 
 export default CandidateIndex;

--- a/resources/assets/js/components/CandidateIndex.js
+++ b/resources/assets/js/components/CandidateIndex.js
@@ -145,8 +145,6 @@ class CandidateIndex extends React.Component {
     // Finally, remove any any empty categories from the array
     categories = categories.filter(function(category) { return category.candidates && category.candidates.length !== 0 });
 
-    console.log(count);
-
     return { count, categories };
   }
 

--- a/resources/assets/js/components/CandidateIndex.js
+++ b/resources/assets/js/components/CandidateIndex.js
@@ -2,6 +2,7 @@ import React from 'react/addons';
 import Gallery from './Gallery';
 import SearchForm from './SearchForm';
 import includes from 'lodash/collection/includes';
+import debounce from 'lodash/function/debounce';
 
 class CandidateIndex extends React.Component {
 
@@ -12,6 +13,7 @@ class CandidateIndex extends React.Component {
 
     this.selectItem = this.selectItem.bind(this);
     this.setQuery = this.setQuery.bind(this);
+    this.setQuery = debounce(this.setQuery, 20, { leading: true });
 
     // Set HTML5 history event listener
     if(typeof window !== 'undefined') {

--- a/resources/assets/js/components/Drawer.js
+++ b/resources/assets/js/components/Drawer.js
@@ -1,8 +1,37 @@
-import React from 'react/addons';
+import React, { Component } from 'react/addons';
 import CandidateDetailView from './CandidateDetailView';
-const { CSSTransitionGroup } = React.addons;
+import { slideUp, slideDown } from '../utilities/scroll';
+const { TransitionGroup } = React.addons;
 
-class DrawerContents extends React.Component {
+class DrawerTransitionGroupChild extends Component {
+
+  componentWillEnter(done) {
+    const node = React.findDOMNode(this);
+    slideDown(node, done);
+  }
+
+  componentWillLeave(done) {
+    const node = React.findDOMNode(this);
+    slideUp(node, done);
+  }
+
+  render() {
+    return React.Children.only(this.props.children);
+  }
+
+}
+
+class DrawerTransitionGroup extends Component {
+  _wrapChild(child) {
+    return <DrawerTransitionGroupChild>{child}</DrawerTransitionGroupChild>;
+  }
+
+  render() {
+    return <TransitionGroup {...this.props} childFactory={this._wrapChild} />;
+  }
+}
+
+class DrawerContents extends Component {
 
   /**
    * Render component.
@@ -19,7 +48,7 @@ class DrawerContents extends React.Component {
 
 }
 
-class Drawer extends React.Component {
+class Drawer extends Component {
 
   /**
    * Send 'close' event to parent component.
@@ -38,9 +67,9 @@ class Drawer extends React.Component {
    */
   render() {
     return (
-      <CSSTransitionGroup transitionName="drawer-animation">
+      <DrawerTransitionGroup>
         {this.props.isOpen ? <DrawerContents candidate={this.props.candidate} close={this.close.bind(this)} /> : null}
-      </CSSTransitionGroup>
+      </DrawerTransitionGroup>
     )
   }
 

--- a/resources/assets/js/components/GalleryRow.js
+++ b/resources/assets/js/components/GalleryRow.js
@@ -3,6 +3,7 @@ import React from 'react/addons';
 import Tile from './Tile';
 import Drawer from './Drawer';
 import { getOffset, scrollToY } from '../utilities/scroll';
+import shallowCompare from '../vendor/shallowCompare';
 
 class GalleryRow extends React.Component {
 
@@ -51,6 +52,17 @@ class GalleryRow extends React.Component {
       this.scrollTop();
     }
   }
+
+  /**
+   * Only re-render this component if props or state change.
+   * @param nextProps
+   * @param nextState
+   * @returns {boolean}
+   */
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  }
+
 
   /**
    * Render component.

--- a/resources/assets/js/components/GalleryRow.js
+++ b/resources/assets/js/components/GalleryRow.js
@@ -39,6 +39,8 @@ class GalleryRow extends React.Component {
    * @param nextProps
    */
   componentWillReceiveProps(nextProps) {
+    if(this.props.selectedItem == nextProps.selectedItem) return;
+
     const hadSelectedTile = this.props.row.some((candidate) => candidate === this.props.selectedItem);
     const hasSelectedTile = nextProps.row.some((candidate) => candidate === nextProps.selectedItem);
 

--- a/resources/assets/js/components/Tile.js
+++ b/resources/assets/js/components/Tile.js
@@ -35,36 +35,17 @@ class Tile extends React.Component {
    * @returns {XML}
    */
   render() {
-    let candidate = this.props.candidate;
-
     const classes = classNames('tile', {
-      'is-active': this.props.selected,
-      '-alternate': this.props.alternate
+      'is-active': this.props.selected
     });
-
-    let content = (
-      <div>
-        <div className='tile__meta'>
-          <h1>{candidate.name}</h1>
-        </div>
-        <img alt={candidate.name} src={candidate.thumbnail} />
-      </div>
-    );
-
-    if(this.props.alternate) {
-      return (
-        <article className={classes}>
-          <div className='wrapper'>
-            {content}
-          </div>
-        </article>
-      );
-    }
 
     return (
       <article className={classes}>
-        <a className='wrapper' href={candidate.url} onClick={this.onClick}>
-          {content}
+        <a className='wrapper' href={this.props.candidate.url} onClick={this.onClick}>
+          <div className='tile__meta'>
+            <h1>{this.props.candidate.name}</h1>
+          </div>
+          <img alt={this.props.candidate.name} src={this.props.candidate.thumbnail} />
           <span className='button -round tile__action'>Vote</span>
         </a>
       </article>

--- a/resources/assets/js/utilities/scroll.js
+++ b/resources/assets/js/utilities/scroll.js
@@ -19,6 +19,62 @@ export function scrollToY(scrollTargetY = 0, speed = 2000) {
 }
 
 /**
+ * jQuery-less version of jQuery's $.slideDown method.
+ * @param element
+ * @param callback
+ */
+export function slideDown(element, callback = function() {}) {
+
+  // Measure final height by creating an invisible clone
+  // @TODO: This should be measured from within the container...
+  var clone = element.cloneNode(true);
+  clone.style.width = element.parentNode.offsetWidth;
+  clone.style.height = 'auto';
+  clone.style.display = 'block';
+  clone.style.position = 'absolute';
+  clone.style.left = '-9999px';
+  document.body.appendChild(clone);
+
+  const targetHeight = outerHeight(clone);
+
+  document.body.removeChild(clone);
+
+  element.style.opacity = 0;
+
+  // ... and animate:
+  animate(function(progress, easing) {
+    element.style.height = `${targetHeight * easing}px`;
+    element.style.opacity = easing;
+  }, function() {
+    element.style.height = null; /* auto */
+    element.style.opacity = 1;
+    callback();
+  }, 0.25);
+
+}
+
+/**
+ * jQuery-less version of jQuery's $.slideUp method.
+ * @param element
+ * @param callback
+ */
+export function slideUp(element, callback = function() {}) {
+  const startHeight = outerHeight(element);
+
+  element.style.opacity = 1;
+
+  animate(function(progress, easing) {
+    element.style.height = `${startHeight - (startHeight * easing)}px`;
+    element.style.opacity = 1 - (1 * easing);
+  }, function() {
+    element.style.height = `0px`;
+    element.style.opacity = 0;
+    callback();
+  }, 0.25);
+
+}
+
+/**
  * Perform an animate using `requestAnimationFrame`.
  * @param callback - Callback to render each frame of the animation
  * @param finalCallback - Optional callback used for final animation frame
@@ -58,6 +114,19 @@ export function animate(callback, finalCallback = callback, time = 1) {
 }
 
 /**
+ * Get element's height including margin.
+ * @param el
+ * @returns {number}
+ */
+export function outerHeight(el) {
+  var height = el.offsetHeight;
+  var style = getComputedStyle(el);
+
+  height += parseInt(style.marginTop) + parseInt(style.marginBottom);
+  return height;
+}
+
+/**
  * Get the pixel offset of a given DOM element on the page.
  * @param {object} element
  * @returns {number} - Pixel offset from top of page
@@ -74,4 +143,4 @@ export function getOffset(element) {
   return offsetTop;
 }
 
-export default { scrollToY, getOffset };
+export default { scrollToY, slideUp, slideDown, outerHeight, getOffset };

--- a/resources/assets/js/utilities/scroll.js
+++ b/resources/assets/js/utilities/scroll.js
@@ -1,30 +1,56 @@
 /**
  * Animate scrolling the viewport to a given offset.
- * @see http://stackoverflow.com/a/26798337
  * @param scrollTargetY - Y offset to scroll to
  * @param speed - Speed of animation
  */
 export function scrollToY(scrollTargetY = 0, speed = 2000) {
   const scrollY = window.scrollY;
-  let currentTime = 0;
 
   // min time .1, max time .8 seconds
   const time = Math.max(.1, Math.min(Math.abs(scrollY - scrollTargetY) / speed, .8));
+
+  // Animate the browser's `scrollTo` method
+  animate(function(progress, easing) {
+    window.scrollTo(0, scrollY + ((scrollTargetY - scrollY) * easing));
+  }, function() {
+    // Scrolling is done!
+    window.scrollTo(0, scrollTargetY);
+  }, time);
+}
+
+/**
+ * Perform an animate using `requestAnimationFrame`.
+ * @param callback - Callback to render each frame of the animation
+ * @param finalCallback - Optional callback used for final animation frame
+ * @param time - Time in seconds (defaults to 1)
+ */
+export function animate(callback, finalCallback = callback, time = 1) {
+  let currentTime = 0;
 
   // Animation loop method.
   function tick() {
     currentTime += 1 / 60;
 
-    const p = currentTime / time;
-    const t = Math.sin(p * (Math.PI / 2));
+    /**
+     * Progress for this frame of the animation (between 0 and 1).
+     * @type {number}
+     */
+    const progress = currentTime / time;
 
-    if (p < 1) {
+    /**
+     * Progress, adjusted to gently ease-out.
+     * @type {number}
+     */
+    const easing = Math.sin(progress * (Math.PI / 2));
+
+    if (progress < 1) {
       window.requestAnimationFrame(tick);
-      window.scrollTo(0, scrollY + ((scrollTargetY - scrollY) * t));
+      callback(progress, easing)
     } else {
-      // Scrolling is done!
-      window.scrollTo(0, scrollTargetY);
+      finalCallback();
     }
+
+    callback(progress, easing);
   }
 
   // Initiate animation loop.

--- a/resources/assets/sass/base/_data.scss
+++ b/resources/assets/sass/base/_data.scss
@@ -1,6 +1,11 @@
 // We store any data URIs in here to keep code readable.
 $svg-prefix: "data:image/svg+xml;charset=US-ASCII,";
 
+
+// Loading Spinner
+// From DoSomething.org Neue
+$data-spinner-svg: $svg-prefix + url-encode("<svg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 18 18'><path fill='#DDD' d='M8.984 16.906c-4.385 0-7.953-3.567-7.953-7.953C1.03 4.568 4.6 1 8.985 1c4.386 0 7.953 3.568 7.953 7.953 0 4.386-3.567 7.953-7.953 7.953zM8.984 4C6.254 4 4.03 6.222 4.03 8.953c0 2.73 2.223 4.953 4.954 4.953 2.73 0 4.953-2.222 4.953-4.953 0-2.73-2.22-4.953-4.953-4.953z'/><path fill='#999' d='M1.03 8.953l.002.03h3l-.002-.03C4.03 6.223 6.253 4 8.984 4V1C4.6 1 1.03 4.568 1.03 8.953z'><animateTransform attributeName='transform' type='rotate' from='0 9 9' to='360 9 9' dur='1.5s' repeatCount='indefinite' /></path></svg>");
+
 //
 // Embedded icons from Open Iconic.
 // Released under MIT and copyright 2014 Waybury.

--- a/resources/assets/sass/components/_pagination.scss
+++ b/resources/assets/sass/components/_pagination.scss
@@ -11,3 +11,9 @@
     color: $gray;
   }
 }
+
+.pagination-link {
+  display: block;
+  text-align: center;
+  margin: $base-spacing;
+}

--- a/resources/assets/sass/components/_pagination.scss
+++ b/resources/assets/sass/components/_pagination.scss
@@ -16,4 +16,20 @@
   display: block;
   text-align: center;
   margin: $base-spacing;
+
+  &.is-autoloading {
+    &:before {
+      content: '';
+      display: block;
+      background: transparent data-url($data-spinner-svg) no-repeat center center;
+      background-size: 32px;
+      height: 32px;
+      width: 32px;
+      margin: 0 auto;
+    }
+
+    span {
+      display: none;
+    }
+  }
 }

--- a/resources/assets/sass/modules/_tile.scss
+++ b/resources/assets/sass/modules/_tile.scss
@@ -1,6 +1,14 @@
 // Tile!
 
 .tile {
+  width: 100%;
+  height: 0;
+  padding-bottom: 100%;
+
+  @include media('medium') {
+    margin-bottom: 2 * $base-spacing;
+  }
+
   // Selected state (i.e. drawer is open)
   &.is-active {
     > .wrapper {
@@ -11,12 +19,8 @@
 
   // Alternate tile appearance
   &.-alternate {
-    width: 100%;
-    height: 0;
-    padding-bottom: 100%;
-
-    > .wrapper {
-      padding-bottom: 0;
+    @include media('medium') {
+      margin-bottom: 0;
     }
 
     .tile__meta {
@@ -37,14 +41,11 @@
   }
 
   > .wrapper {
+    @include clearfix;
     position: relative;
     display: block;
     width: 100%;
     transition: transform 0.5s;
-
-    @include media('medium') {
-      padding-bottom: 2 * $base-spacing;
-    }
   }
 
   img {
@@ -95,7 +96,7 @@
     }
 
     @include media('medium') {
-      bottom: $base-spacing;
+      bottom: -1 * $base-spacing;
       left: 0;
       right: 0;
       margin-left: auto;

--- a/resources/assets/sass/modules/_tile.scss
+++ b/resources/assets/sass/modules/_tile.scss
@@ -1,8 +1,6 @@
 // Tile!
 
 .tile {
-  transform: translateZ(0);
-
   // Selected state (i.e. drawer is open)
   &.is-active {
     > .wrapper {

--- a/resources/views/candidates/index.blade.php
+++ b/resources/views/candidates/index.blade.php
@@ -3,7 +3,7 @@
 @section('content')
     @if($categories)
 
-        @react('CandidateIndex', compact('categories', 'query'))
+        @react('CandidateIndex', compact('categories', 'query', 'limit'))
 
         <div class="wrapper -narrow">
             <h4>Was there a {{ setting('candidate_type') }} we missed?</h4>


### PR DESCRIPTION
# Performance improvements

I took some time to work on improving performance on the Voting App. Particularly, we were running into issues where mobile devices were struggling with the number of DOM nodes (and large amount of images to download) on the page when showing all ~200 candidates.

To improve initial renders, we now only render the first 16 candidates on page load. As the user scrolls, we add more candidates to the page (but only adding them in manageable batches of 25). Users on older browsers can hit a "Show More" button to get more results.

I also moved from using CSS transitions to JavaScript animations for showing/hiding the drawer. Since the drawer animation affects layout (we're animating height, and the rest of the page has to recalculate layout), CSS transitions actually seem to give a pretty big performance penalty when there are a lot of other elements lower on the page (such as when opening the drawer on the first row).

I attached some performance profiles for initial render before & after. With lazy-loading, initial render became a bit over 5x faster. It also decreased the initial page download from about 6MB (yikes) to 657kb (much better).
#### Before

![screen shot 2015-07-09 at 1 09 14 pm](https://cloud.githubusercontent.com/assets/583202/8601768/3625b244-263c-11e5-80e6-611cdf72efc6.png)
#### After

![screen shot 2015-07-09 at 1 08 00 pm](https://cloud.githubusercontent.com/assets/583202/8601770/3af465ea-263c-11e5-982f-95d5245bbd4a.png)

For review: @DoSomething/front-end 
