### PR TITLE
Set production environment for build.

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -23,7 +23,9 @@ build:
       - wercker/bundle-install@1.1.1
       - script:
           name: build assets
-          code: gulp --production
+          code: |-
+            export NODE_ENV=production
+            gulp --production
 
 deploy:
   steps:


### PR DESCRIPTION
# Changes

Make sure `NODE_ENV` is set to `production` when building for production, which allows Uglify to do dead-code elimination on some of React's development helpers. This cuts pre-gzip bundle size by about 32kb.

For review: @DoSomething/front-end 
