### PR TITLE
Closed state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ RABBITMQ_VHOST = vhost
 VOTE_ROUTING_KEY = votingapp.event.vote
 VOTE_TEMPLATE = mb-votingapp-vote
 
+CLOSED_FORM_ROUTING_KEY = votingapp.event.closed
+CLOSED_TEMPLATE = mb-votingapp-closed
+
 REGISTER_ROUTING_KEY = votingapp.user.registration
 REGISTER_ACTIVITY = votingapp_signup
 REGISTER_TEMPLATE = mb-votingapp-signup

--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,7 @@ RABBITMQ_PASSWORD = guest
 RABBITMQ_VHOST = vhost
 
 VOTE_ROUTING_KEY = votingapp.event.vote
-VOTE_ACTIVITY = votingapp_vote
 VOTE_TEMPLATE = mb-votingapp-vote
-VOTE_EMAIL_TAG = votingapp_vote
 
 REGISTER_ROUTING_KEY = votingapp.user.registration
 REGISTER_ACTIVITY = votingapp_signup

--- a/app/Handlers/Events/SendFirstVoteMessage.php
+++ b/app/Handlers/Events/SendFirstVoteMessage.php
@@ -1,10 +1,22 @@
 <?php namespace VotingApp\Handlers\Events;
 
 use VotingApp\Events\UserCastFirstVote;
-use MessageBroker;
+use VotingApp\Services\MessageBroker;
 
 class SendFirstVoteMessage
 {
+
+    /**
+     * The Message Broker handles sending messages.
+     *
+     * @var MessageBroker
+     */
+    protected $broker;
+
+    public function __construct(MessageBroker $broker)
+    {
+        $this->broker = $broker;
+    }
 
     /**
      * Handle the event.
@@ -14,37 +26,17 @@ class SendFirstVoteMessage
      */
     public function handle(UserCastFirstVote $event)
     {
-        // Don't send messages locally.
-        if (app()->environment('local', 'testing')) {
-            return;
-        }
-
-        // Configure the message broker connection
-        $credentials = config('services.message_broker.credentials');
-        $config = config('services.message_broker.config');
-        $config['routingKey'] = env('VOTE_ROUTING_KEY', 'votingapp.event.vote');
-        $broker = new MessageBroker($credentials, $config);
-
         $payload = [
-            // User information
             'first_name' => $event->user->first_name,
             'birthdate_timestamp' => strtotime($event->user->birthdate), // Message Broker expects UNIX timestamp
             'country_code' => $event->user->country_code,
-
-            // Candidate information.
             'candidate_id' => $event->candidate->id,
             'candidate_name' => $event->candidate->name,
-
-            // Request specific information
-            'activity' => env('VOTE_ACTIVITY', 'vote'),
-            'application_id' => env('MESSAGE_BROKER_APPLICATION_ID'),
-            'activity_timestamp' => time(),
         ];
 
         // Send fields for domestic users
         if($event->user->country_code === 'US') {
             $payload['mobile'] = $event->user->phone;
-            $payload['mc_opt_in_path_id'] = env('MC_OPT_IN_PATH');
             $payload['mobile_tags'] = [
                 env('APP_NAME_TAG', 'votingapp'),
                 $event->candidate->id,
@@ -56,9 +48,6 @@ class SendFirstVoteMessage
         if($event->user->country_code !== 'US') {
             $payload['email'] = $event->user->email;
             $payload['subscribed'] = 1;
-            $payload['mailchimp_grouping_id'] = env('MAILCHIMP_GROUP_ID');
-            $payload['mailchimp_group_name'] = env('MAILCHIMP_GROUP_NAME');
-            $payload['mailchimp_list_id'] = env('MAILCHIMP_LIST_ID');
             $payload['email_template'] = env('VOTE_TEMPLATE', 'mb-votingapp-vote');
             $payload['email_tags'] = [
                 env('APP_NAME_TAG', 'votingapp'),
@@ -73,8 +62,8 @@ class SendFirstVoteMessage
             ];
         }
 
-        $payload = serialize($payload);
-        $broker->publishMessage($payload);
+        $routingKey = env('VOTE_ROUTING_KEY', 'votingapp.event.vote');
+        $this->broker->publish('vote', $payload, $routingKey);
     }
 
 }

--- a/app/Http/Controllers/CandidatesController.php
+++ b/app/Http/Controllers/CandidatesController.php
@@ -83,7 +83,6 @@ class CandidatesController extends Controller
         $candidates = $query->get();
 
         return view('candidates.adminIndex', compact('candidates'));
-
     }
 
 

--- a/app/Services/MessageBroker.php
+++ b/app/Services/MessageBroker.php
@@ -13,7 +13,6 @@ class MessageBroker
      * @param string $routingKey
      */
     public function publishRaw($payload, $routingKey) {
-        dd('sending!');
         // Don't send messages locally.
         if (app()->environment('local', 'testing')) {
             return;

--- a/app/Services/MessageBroker.php
+++ b/app/Services/MessageBroker.php
@@ -1,0 +1,56 @@
+<?php namespace VotingApp\Services;
+
+use MessageBroker as MessageBrokerConnection;
+
+class MessageBroker
+{
+
+    /**
+     * Serialize and send payload to the Message Broker using a
+     * given routing key.
+     *
+     * @param array $payload
+     * @param string $routingKey
+     */
+    public function publishRaw($payload, $routingKey) {
+        dd('sending!');
+        // Don't send messages locally.
+        if (app()->environment('local', 'testing')) {
+            return;
+        }
+
+        // Configure the message broker connection
+        $credentials = config('services.message_broker.credentials');
+        $config = config('services.message_broker.config');
+        $config['routingKey'] = $routingKey;
+        $broker = new MessageBrokerConnection($credentials, $config);
+
+        $serializedPayload = serialize($payload);
+        $broker->publishMessage($serializedPayload);
+    }
+
+    /**
+     * Append expected configuration variables to the payload, and
+     * then send to the Message Broker.
+     *
+     * @param string $activity
+     * @param array $payload
+     * @param string $routingKey
+     */
+    public function publish($activity, $payload, $routingKey)
+    {
+        // Set common configuration values:
+        $payload['application_id'] = env('MESSAGE_BROKER_APPLICATION_ID');
+        $payload['mc_opt_in_path_id'] = env('MC_OPT_IN_PATH');
+        $payload['mailchimp_grouping_id'] = env('MAILCHIMP_GROUP_ID');
+        $payload['mailchimp_group_name'] = env('MAILCHIMP_GROUP_NAME');
+        $payload['mailchimp_list_id'] = env('MAILCHIMP_LIST_ID');
+
+        // Add activity type and timestamp
+        $payload['activity'] = $activity;
+        $payload['activity_timestamp'] = time();
+
+        $this->publishRaw($payload, $routingKey);
+    }
+
+}

--- a/app/Services/Northstar.php
+++ b/app/Services/Northstar.php
@@ -49,7 +49,10 @@ class Northstar
 
         if($e instanceof RequestException)
         {
-            $info['body'] = $e->getResponse()->json();
+            $response = $e->getResponse();
+            if($response) {
+                $info['body'] = $response->json();
+            }
         }
 
         logger('Northstar API Exception', $info);
@@ -87,7 +90,7 @@ class Northstar
             $json = $response->json();
 
             return $json['data']['_id'];
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             $this->logException($e);
             return null;
         }

--- a/database/migrations/2015_07_27_155237_make_northstar_id_nullable.php
+++ b/database/migrations/2015_07_27_155237_make_northstar_id_nullable.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MakeNorthstarIdNullable extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('northstar_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // ...
+	}
+
+}

--- a/resources/views/users/partials/closed.blade.php
+++ b/resources/views/users/partials/closed.blade.php
@@ -2,8 +2,6 @@
     <div class="wrapper">
         <h1 class="highlighted">Sign up for updates!</h1>
         <p>Voting is closed, but sign up to be notified when we're ready!</p>
-    </div>
-    <div class="wrapper">
         {!! Form::open(['route' => 'users.store']) !!}
         @include('auth.form')
         {!! Form::submit('Send me updates!', ['class' => 'button -primary']) !!}


### PR DESCRIPTION
# Changes

Closes #286. This hooks up the closed state form to forward users to Message Broker.

It also creates a wrapper [`MessageBroker`](https://github.com/DFurnes/voting-app/blob/closed-state/app/Services/MessageBroker.php) service class that handles configuring the `AMQPConnection` and adding common configuration values (like `application_id`, `mailchimp_grouping_id`, `mc_opt_in_path_id`, etc.) so we don't have to duplicate that logic for every single request.

For review: @angaither @DeeZone 
