### PR TITLE
Winners interface updates

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -32,6 +32,7 @@ import shareLink from './utilities/share-link';
 // Components
 import CandidateIndex from './components/CandidateIndex';
 import CategoryIndex from './components/CategoryIndex';
+import WinnerIndex from './components/WinnerIndex';
 
 /**
  * Let's go!
@@ -53,5 +54,6 @@ ready(function() {
   rehydrate({
     'CandidateIndex': CandidateIndex,
     'CategoryIndex': CategoryIndex,
+    'WinnerIndex': WinnerIndex,
   });
 });

--- a/resources/assets/js/components/CandidateDetailView.js
+++ b/resources/assets/js/components/CandidateDetailView.js
@@ -4,7 +4,7 @@ import AlternateTile from './AlternateTile';
 class CandidateDetailView extends Component {
 
   static propTypes = {
-    candidate: PropTypes.shape({
+    item: PropTypes.shape({
       id: PropTypes.number,
       name: PropTypes.string,
       description: PropTypes.string,
@@ -25,10 +25,10 @@ class CandidateDetailView extends Component {
     let formMarkup = document.getElementById('form-template').innerHTML;
 
     // Replace token values for this particular candidate
-    formMarkup = formMarkup.replace(/CANDIDATE_ID/g, this.props.candidate.id)
-                           .replace(/CANDIDATE_NAME/g, this.props.candidate.name)
-                           .replace(/CANDIDATE_LINK/g, this.props.candidate.url)
-                           .replace(/TWITTER_NAME/g, this.props.candidate.share_name);
+    formMarkup = formMarkup.replace(/CANDIDATE_ID/g, this.props.item.id)
+                           .replace(/CANDIDATE_NAME/g, this.props.item.name)
+                           .replace(/CANDIDATE_LINK/g, this.props.item.url)
+                           .replace(/TWITTER_NAME/g, this.props.item.share_name);
 
     return {
       __html: formMarkup,
@@ -44,8 +44,8 @@ class CandidateDetailView extends Component {
       <div className="candidate">
         <div className="wrapper">
           <div className="candidate__info">
-            <AlternateTile candidate={this.props.candidate} />
-            <p className="candidate__description">{this.props.candidate.description}</p>
+            <AlternateTile candidate={this.props.item} />
+            <p className="candidate__description">{this.props.item.description}</p>
           </div>
 
           <div className="candidate__actions" dangerouslySetInnerHTML={this.getFormMarkup()} />

--- a/resources/assets/js/components/CandidateIndex.js
+++ b/resources/assets/js/components/CandidateIndex.js
@@ -6,6 +6,7 @@ import { getOffset } from '../utilities/dom';
 
 import Gallery from './Gallery';
 import SearchForm from './SearchForm';
+import Tile from './Tile';
 
 class CandidateIndex extends Component {
 
@@ -160,7 +161,11 @@ class CandidateIndex extends Component {
     const filtered = this.getFilteredCandidates();
 
     const galleries = filtered.categories.map((category) => {
-      return <Gallery key={category.id} name={category.name} items={category.candidates} selectItem={this.onSelectItem} selectedItem={this.state.selectedItem} />;
+      return (
+        <Gallery key={category.id} name={category.name} selectItem={this.onSelectItem} selectedItem={this.state.selectedItem}>
+          {category.candidates.map((candidate) => <Tile candidate={candidate} />)}
+        </Gallery>
+      );
     });
 
     const shouldShowPagination = this.state.limit < filtered.count;

--- a/resources/assets/js/components/CandidateIndex.js
+++ b/resources/assets/js/components/CandidateIndex.js
@@ -4,6 +4,7 @@ import debounce from 'lodash/function/debounce';
 import includes from 'lodash/collection/includes';
 import { getOffset } from '../utilities/dom';
 
+import CandidateDetailView from './CandidateDetailView';
 import Gallery from './Gallery';
 import SearchForm from './SearchForm';
 import Tile from './Tile';
@@ -25,7 +26,7 @@ class CandidateIndex extends Component {
 
     this.state = this.getState(props);
 
-    this.onSelectItem = this.onSelectItem.bind(this);
+    this.onSelect = this.onSelect.bind(this);
     this.onSetQuery = this.onSetQuery.bind(this);
     this.onSetQuery = debounce(this.onSetQuery, 20, { leading: true });
     this.onInfiniteScroll = this.onInfiniteScroll.bind(this);
@@ -79,14 +80,14 @@ class CandidateIndex extends Component {
    * Set or unset the selected item to show details for.
    * @param {object} item - Selected item
    */
-  onSelectItem(item) {
+  onSelect(item) {
     // De-select if trying to select the same item again.
-    if (this.state.selectedItem === item.props.candidate) {
+    if (this.state.selectedItem === item) {
       this.setState({selectedItem: null});
       return;
     }
 
-    this.setState({selectedItem: item.props.candidate});
+    this.setState({selectedItem: item});
   }
 
   /**
@@ -162,8 +163,8 @@ class CandidateIndex extends Component {
 
     const galleries = filtered.categories.map((category) => {
       return (
-        <Gallery key={category.id} name={category.name} selectItem={this.onSelectItem} selectedItem={this.state.selectedItem}>
-          {category.candidates.map((candidate) => <Tile candidate={candidate} />)}
+        <Gallery key={category.id} name={category.name} onSelect={this.onSelect} selectedItem={this.state.selectedItem} detailView={CandidateDetailView}>
+          {category.candidates.map((candidate) => <Tile key={candidate.key} id={candidate.key} item={candidate} />)}
         </Gallery>
       );
     });

--- a/resources/assets/js/components/CategoryIndex.js
+++ b/resources/assets/js/components/CategoryIndex.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react/addons';
 import Gallery from './Gallery';
+import CandidateDetailView from './CandidateDetailView';
 import Tile from './Tile';
 
 class CategoryIndex extends Component {
@@ -20,25 +21,25 @@ class CategoryIndex extends Component {
     });
 
     this.state = {
-      selectedItem: null,
       candidates: candidates,
+      selectedItem: null,
     };
 
-    this.onSelectItem = this.onSelectItem.bind(this);
+    this.onSelect = this.onSelect.bind(this);
   }
 
   /**
    * Set or unset the selected item to show details for.
    * @param {object} item - Selected item
    */
-  onSelectItem(item) {
+  onSelect(item) {
     // De-select if trying to select the same item again.
-    if (this.state.selectedItem === item.props.candidate) {
+    if (this.state.selectedItem === item) {
       this.setState({selectedItem: null});
       return;
     }
 
-    this.setState({selectedItem: item.props.candidate});
+    this.setState({selectedItem: item});
   }
 
   /**
@@ -47,8 +48,8 @@ class CategoryIndex extends Component {
    */
   render() {
     return (
-      <Gallery name={this.props.name} selectItem={this.onSelectItem} selectedItem={this.state.selectedItem}>
-        {this.props.candidates.map((candidate) => <Tile candidate={candidate} />)}
+      <Gallery name={this.props.name} onSelect={this.onSelect} selectedItem={this.state.selectedItem} detailView={CandidateDetailView}>
+        {this.props.candidates.map((candidate) => <Tile key={candidate.key} id={candidate.key} item={candidate} />)}
       </Gallery>
     );
   }

--- a/resources/assets/js/components/CategoryIndex.js
+++ b/resources/assets/js/components/CategoryIndex.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react/addons';
 import Gallery from './Gallery';
+import Tile from './Tile';
 
 class CategoryIndex extends Component {
 
@@ -46,7 +47,9 @@ class CategoryIndex extends Component {
    */
   render() {
     return (
-      <Gallery name={this.props.name} items={this.props.candidates} selectItem={this.onSelectItem} selectedItem={this.state.selectedItem} />
+      <Gallery name={this.props.name} selectItem={this.onSelectItem} selectedItem={this.state.selectedItem}>
+        {this.props.candidates.map((candidate) => <Tile candidate={candidate} />)}
+      </Gallery>
     );
   }
 

--- a/resources/assets/js/components/Drawer.js
+++ b/resources/assets/js/components/Drawer.js
@@ -1,13 +1,13 @@
 import React, { Component, PropTypes } from 'react/addons';
 import DrawerTransitionGroup from './DrawerTransitionGroup';
-import CandidateDetailView from './CandidateDetailView';
 
 class Drawer extends Component {
 
   static propTypes = {
     candidate: PropTypes.object,
-    selectItem: PropTypes.func,
+    onSelect: PropTypes.func,
     isOpen: PropTypes.bool,
+    children: PropTypes.element.isRequired,
   };
 
   static defaultProps = {
@@ -28,7 +28,7 @@ class Drawer extends Component {
     event.preventDefault();
 
     // De-select this item.
-    this.props.selectItem(this);
+    this.props.onSelect(this);
   }
 
   /**
@@ -41,7 +41,7 @@ class Drawer extends Component {
     if (this.props.isOpen) {
       contents = (
         <div className="drawer">
-          <CandidateDetailView candidate={this.props.candidate} />
+          {this.props.children}
           <a href="#" className="drawer__close" onClick={this.onClose}><span>Close</span></a>
         </div>
       );

--- a/resources/assets/js/components/Gallery.js
+++ b/resources/assets/js/components/Gallery.js
@@ -7,7 +7,7 @@ class Gallery extends Component {
 
   static propTypes = {
     name: PropTypes.string,
-    items: PropTypes.array,
+    children: PropTypes.arrayOf(PropTypes.element),
     selectedItem: PropTypes.object,
     selectItem: PropTypes.func,
   };
@@ -65,7 +65,7 @@ class Gallery extends Component {
    */
   render() {
     // Show "empty state" if no items
-    if (this.props.items.length === 0) {
+    if (this.props.children.length === 0) {
       return (
         <div className="gallery">
           <div className="empty">No matches!</div>
@@ -73,10 +73,14 @@ class Gallery extends Component {
       );
     }
 
-    const chunkedItems = chunk(this.props.items, this.state.itemsPerRow);
+    const chunkedChildren = chunk(this.props.children, this.state.itemsPerRow);
 
-    const rows = chunkedItems.map((row, index) => {
-      return <GalleryRow key={index} row={row} selectedItem={this.props.selectedItem} selectItem={this.props.selectItem} />;
+    const rows = chunkedChildren.map((row, index) => {
+      return (
+        <GalleryRow key={index} selectedItem={this.props.selectedItem} selectItem={this.props.selectItem}>
+          {row}
+        </GalleryRow>
+      );
     });
 
     return (

--- a/resources/assets/js/components/Gallery.js
+++ b/resources/assets/js/components/Gallery.js
@@ -8,8 +8,9 @@ class Gallery extends Component {
   static propTypes = {
     name: PropTypes.string,
     children: PropTypes.arrayOf(PropTypes.element),
+    detailView: PropTypes.instanceOf(Component),
     selectedItem: PropTypes.object,
-    selectItem: PropTypes.func,
+    onSelect: PropTypes.func,
   };
 
   static defaultProps = {
@@ -77,7 +78,7 @@ class Gallery extends Component {
 
     const rows = chunkedChildren.map((row, index) => {
       return (
-        <GalleryRow key={index} selectedItem={this.props.selectedItem} selectItem={this.props.selectItem}>
+        <GalleryRow key={index} detailView={this.props.detailView} selectedItem={this.props.selectedItem} onSelect={this.props.onSelect}>
           {row}
         </GalleryRow>
       );

--- a/resources/assets/js/components/GalleryRow.js
+++ b/resources/assets/js/components/GalleryRow.js
@@ -1,16 +1,19 @@
 import React, { Component, PropTypes } from 'react/addons';
 const { cloneWithProps } = React.addons;
-
-import Drawer from './Drawer';
 import { getOffset, scrollToY } from '../utilities/dom';
 import shallowCompare from '../vendor/shallowCompare';
+
+import Drawer from './Drawer';
+// import CandidateDetailView from './CandidateDetailView';
+
 
 class GalleryRow extends Component {
 
   static propTypes = {
     children: PropTypes.arrayOf(PropTypes.element),
+    detailView: PropTypes.instanceOf(Component),
     selectedItem: PropTypes.object,
-    selectItem: PropTypes.func,
+    onSelect: PropTypes.func,
   };
 
   /**
@@ -19,13 +22,14 @@ class GalleryRow extends Component {
    * @param {object} nextProps - Props that the component will receive
    */
   componentWillReceiveProps(nextProps) {
+    if (!nextProps.selectedItem) return;
     if (this.props.selectedItem === nextProps.selectedItem) return;
 
-    const hadSelectedTile = this.props.children.some((child) => child.props.candidate === this.props.selectedItem);
-    const hasSelectedTile = nextProps.children.some((child) => child.props.candidate === nextProps.selectedItem);
+    const hadSelectedTile = this.props.children.some((child) => child.props.item === this.props.selectedItem);
+    const hasSelectedTile = nextProps.children.some((child) => child.props.item === nextProps.selectedItem);
 
-    const prevKey = this.props.selectedItem ? this.props.selectedItem.key : 0;
-    const nextKey = nextProps.selectedItem ? nextProps.selectedItem.key : -1;
+    const prevKey = this.props.selectedItem ? this.props.selectedItem.id : 0;
+    const nextKey = nextProps.selectedItem ? nextProps.selectedItem.id : -1;
     const previousTileWasAbove = prevKey < nextKey;
 
     if (!hadSelectedTile && hasSelectedTile) {
@@ -80,14 +84,14 @@ class GalleryRow extends Component {
 
     // Build each tile in the row
     const tiles = this.props.children.map((child) => {
-      const selected = child.props.candidate === this.props.selectedItem;
+      const selected = child.props.item === this.props.selectedItem;
       if (selected) {
         hasSelectedTile = selected;
       }
 
       return (
-        <li key={child.props.candidate.key} className="gallery__item">
-          {cloneWithProps(child, {selected: selected, onClick: this.props.selectItem})}
+        <li key={child.key} className="gallery__item">
+          {cloneWithProps(child, {selected: selected, onClick: this.props.onSelect})}
         </li>
       );
     });
@@ -96,7 +100,9 @@ class GalleryRow extends Component {
     return (
       <div>
         {tiles}
-        <Drawer isOpen={hasSelectedTile} candidate={this.props.selectedItem} selectItem={this.props.selectItem} />
+        <Drawer isOpen={hasSelectedTile} onSelect={this.props.onSelect}>
+          <this.props.detailView item={this.props.selectedItem} />
+        </Drawer>
       </div>
     );
   }

--- a/resources/assets/js/components/GalleryRow.js
+++ b/resources/assets/js/components/GalleryRow.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react/addons';
+const { cloneWithProps } = React.addons;
 
-import Tile from './Tile';
 import Drawer from './Drawer';
 import { getOffset, scrollToY } from '../utilities/dom';
 import shallowCompare from '../vendor/shallowCompare';
@@ -8,9 +8,7 @@ import shallowCompare from '../vendor/shallowCompare';
 class GalleryRow extends Component {
 
   static propTypes = {
-    row: PropTypes.arrayOf(PropTypes.shape({
-      key: PropTypes.number,
-    })),
+    children: PropTypes.arrayOf(PropTypes.element),
     selectedItem: PropTypes.object,
     selectItem: PropTypes.func,
   };
@@ -23,8 +21,8 @@ class GalleryRow extends Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.selectedItem === nextProps.selectedItem) return;
 
-    const hadSelectedTile = this.props.row.some((candidate) => candidate === this.props.selectedItem);
-    const hasSelectedTile = nextProps.row.some((candidate) => candidate === nextProps.selectedItem);
+    const hadSelectedTile = this.props.children.some((child) => child.props.candidate === this.props.selectedItem);
+    const hasSelectedTile = nextProps.children.some((child) => child.props.candidate === nextProps.selectedItem);
 
     const prevKey = this.props.selectedItem ? this.props.selectedItem.key : 0;
     const nextKey = nextProps.selectedItem ? nextProps.selectedItem.key : -1;
@@ -78,17 +76,18 @@ class GalleryRow extends Component {
    * @returns {XML}
    */
   render() {
-    // Build each tile in the row
     let hasSelectedTile = false;
-    const tiles = this.props.row.map((candidate) => {
-      const selected = candidate === this.props.selectedItem;
+
+    // Build each tile in the row
+    const tiles = this.props.children.map((child) => {
+      const selected = child.props.candidate === this.props.selectedItem;
       if (selected) {
         hasSelectedTile = selected;
       }
 
       return (
-        <li key={candidate.key} className="gallery__item">
-          <Tile candidate={candidate} selected={selected} onClick={this.props.selectItem} />
+        <li key={child.props.candidate.key} className="gallery__item">
+          {cloneWithProps(child, {selected: selected, onClick: this.props.selectItem})}
         </li>
       );
     });

--- a/resources/assets/js/components/Tile.js
+++ b/resources/assets/js/components/Tile.js
@@ -36,7 +36,6 @@ class Tile extends Component {
    */
   onClick(event) {
     event.preventDefault();
-
     this.props.onClick(this);
   }
 

--- a/resources/assets/js/components/Tile.js
+++ b/resources/assets/js/components/Tile.js
@@ -5,7 +5,8 @@ import shallowCompare from '../vendor/shallowCompare';
 class Tile extends Component {
 
   static propTypes = {
-    candidate: PropTypes.shape({
+    id: PropTypes.number,
+    item: PropTypes.shape({
       name: PropTypes.string,
       url: PropTypes.string,
       thumbnail: PropTypes.string,
@@ -36,7 +37,7 @@ class Tile extends Component {
    */
   onClick(event) {
     event.preventDefault();
-    this.props.onClick(this);
+    this.props.onClick(this.props.item);
   }
 
   /**
@@ -50,11 +51,11 @@ class Tile extends Component {
 
     return (
       <article className={classes}>
-        <a className="wrapper" href={this.props.candidate.url} onClick={this.onClick}>
+        <a className="wrapper" href={this.props.item.url} onClick={this.onClick}>
           <div className="tile__meta">
-            <h1>{this.props.candidate.name}</h1>
+            <h1>{this.props.item.name}</h1>
           </div>
-          <img alt={this.props.candidate.name} src={this.props.candidate.thumbnail} />
+          <img alt={this.props.item.name} src={this.props.item.thumbnail} />
           <span className="button -round tile__action">Vote</span>
         </a>
       </article>

--- a/resources/assets/js/components/WinnerDetailView.js
+++ b/resources/assets/js/components/WinnerDetailView.js
@@ -1,0 +1,44 @@
+import React, { Component, PropTypes } from 'react/addons';
+import AlternateTile from './AlternateTile';
+import ordinalize from '../utilities/ordinalize';
+
+class WinnerDetailView extends Component {
+
+  static propTypes = {
+    item: PropTypes.shape({
+      rank: PropTypes.number,
+      description: PropTypes.string,
+      candidate: PropTypes.shape({
+        name: PropTypes.string,
+        description: PropTypes.string,
+        url: PropTypes.string,
+        thumbnail: PropTypes.string,
+      }),
+    }),
+  };
+
+  /**
+   * Render component.
+   * @returns {XML}
+   */
+  render() {
+    return (
+      <div className="candidate">
+        <div className="wrapper">
+          <div className="candidate__info">
+            <AlternateTile candidate={this.props.item.candidate} />
+            <p className="candidate__description">{this.props.item.candidate.description}</p>
+          </div>
+
+          <div className="candidate__actions">
+            <h2 className="heading -hero">{this.props.item.candidate.name} came in {ordinalize(this.props.item.rank)} place.</h2>
+            {this.props.item.description}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default WinnerDetailView;

--- a/resources/assets/js/components/WinnerIndex.js
+++ b/resources/assets/js/components/WinnerIndex.js
@@ -1,0 +1,65 @@
+import React, { Component, PropTypes } from 'react/addons';
+import Gallery from './Gallery';
+import WinnerDetailView from './WinnerDetailView';
+import WinnerTile from './WinnerTile';
+
+class WinnerIndex extends Component {
+
+  static propTypes = {
+    name: PropTypes.string,
+    winners: PropTypes.array,
+  };
+
+  static defaultProps = {
+    name: 'Winners',
+    winners: [],
+  };
+
+  constructor(props) {
+    super(props);
+
+    // Assign incremental key to candidates
+    let i = 1;
+    const winners = props.winners.map(function(candidate) {
+      candidate.key = i++;
+      return candidate;
+    });
+
+    this.state = {
+      winners: winners,
+      selectedItem: null,
+    };
+
+    this.onSelect = this.onSelect.bind(this);
+  }
+
+  /**
+   * Set or unset the selected item to show details for.
+   * @param {object} item - Selected item
+   */
+  onSelect(item) {
+    // De-select if trying to select the same item again.
+    if (this.state.selectedItem === item) {
+      this.setState({selectedItem: null});
+      return;
+    }
+
+    this.setState({selectedItem: item});
+  }
+
+  /**
+   * Render component.
+   * @returns {XML}
+   */
+  render() {
+    return (
+      <Gallery name={this.props.name} onSelect={this.onSelect} selectedItem={this.state.selectedItem} detailView={WinnerDetailView}>
+        {this.state.winners.map((winner) => <WinnerTile key={winner.key} id={winner.key} item={winner} />)}
+      </Gallery>
+    );
+  }
+
+}
+
+export default WinnerIndex;
+

--- a/resources/assets/js/components/WinnerTile.js
+++ b/resources/assets/js/components/WinnerTile.js
@@ -1,0 +1,71 @@
+import React, { Component, PropTypes } from 'react/addons';
+import classNames from 'classnames';
+import shallowCompare from '../vendor/shallowCompare';
+
+class WinnerTile extends Component {
+
+  static propTypes = {
+    id: PropTypes.number,
+    item: PropTypes.shape({
+      rank: PropTypes.number,
+      description: PropTypes.string,
+      candidate: PropTypes.shape({
+        name: PropTypes.string,
+        url: PropTypes.string,
+        thumbnail: PropTypes.string,
+      }),
+    }),
+    selected: PropTypes.bool,
+    onClick: PropTypes.func,
+  };
+
+  constructor() {
+    super();
+
+    this.onClick = this.onClick.bind(this);
+  }
+
+  /**
+   * Only re-render this component if props or state change.
+   * @param {object} nextProps - Props that the component will receive
+   * @param {object} nextState - State that the component will receive
+   * @returns {boolean}
+   */
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  }
+
+  /**
+   * Send click event to parent component.
+   * @param {MouseEvent} event - 'click'
+   */
+  onClick(event) {
+    event.preventDefault();
+    this.props.onClick(this.props.item);
+  }
+
+  /**
+   * Render component.
+   * @returns {XML}
+   */
+  render() {
+    const classes = classNames('tile', {
+      'is-active': this.props.selected,
+    });
+
+    return (
+      <article className={classes}>
+        <a className="wrapper" href={this.props.item.candidate.url} onClick={this.onClick}>
+          <div className="tile__meta">
+            <h1>{this.props.item.candidate.name}</h1>
+          </div>
+          <img alt={this.props.item.candidate.name} src={this.props.item.candidate.thumbnail} />
+          <span className="button -round tile__action">{this.props.item.rank}</span>
+        </a>
+      </article>
+    );
+  }
+
+}
+
+export default WinnerTile;

--- a/resources/assets/js/utilities/ordinalize.js
+++ b/resources/assets/js/utilities/ordinalize.js
@@ -1,0 +1,27 @@
+/**
+ * Return the given number with its ordinal suffix.
+ * @see http://stackoverflow.com/a/13627586
+ *
+ * @param {number} number - Integer to append ordinal suffix to
+ * @returns {string} Formatted number
+ */
+function ordinalize(number) {
+  const j = number % 10;
+  const k = number % 100;
+
+  if (j === 1 && k !== 11) {
+    return `${number}st`;
+  }
+
+  if (j === 2 && k !== 12) {
+    return `${number}nd`;
+  }
+
+  if (j === 3 && k !== 13) {
+    return `${number}rd`;
+  }
+
+  return `${number}th`;
+}
+
+export default ordinalize;

--- a/resources/views/candidates/index.blade.php
+++ b/resources/views/candidates/index.blade.php
@@ -1,7 +1,11 @@
 @extends('app')
 
 @section('content')
-    @if($categories)
+    @if(setting('show_winners'))
+        @react('WinnerIndex', ['winners' => $winners, 'name' => 'Winners'])
+    @endif
+
+    @if(!setting('show_winners') && $categories)
 
         @react('CandidateIndex', compact('categories', 'query', 'limit'))
 

--- a/resources/views/votes/form.blade.php
+++ b/resources/views/votes/form.blade.php
@@ -1,11 +1,11 @@
 {{-- If voting is disabled, show a 'voting is closed' message. --}}
 @if(!setting('enable_voting'))
     <p class="heading -alpha">Voting is closed for {{{ setting('site_title') }}}.</p>
-    If winners are not being shown...
+    {{-- If winners are not being shown... --}}
     @if(!setting('show_winners'))
         <p class="heading -gamma">We'll post the results soon!</p>
-        Winners being shown
     @else
+        {{-- Winners being shown --}}
         <p>{{ $winner->description or "WINNER_DESCRIPTION" }}</p>
     @endif
 


### PR DESCRIPTION
# Changes
- Updates the winners interface to use swanky new React drawers.
- Refactor the `Gallery` and `Drawer` components so they can be reused easily in multiple places. Each one now accepts a set of child components (e.g. `Tile`s or `WinnerTile`s) and a detail view to be used for the open drawer (e.g. `CandidateDetailView` or `WinnerDetailView`).

For review: @DoSomething/front-end 
## Example Code

Before:

``` jsx
<Gallery items={candidates}/>
```

After:

``` jsx
<Gallery detailView={CandidateDetailView}>
   <Tile item={candidate1} />
   <Tile item={candidate2} />
   <Tile item={candidate3} />
</Gallery>
```
