### PR TITLE
Fix errors on server rendering process.

### DIFF
--- a/bootstrap/react_server.js
+++ b/bootstrap/react_server.js
@@ -6,7 +6,9 @@
  *
  * @see https://babeljs.io/docs/usage/require/
  */
-require('babel/register');
+require('babel/register')({
+  optional: ["es7.classProperties"]
+});
 
 /**
  * Bootstrap our server process. This is responsible for

--- a/resources/assets/js/server.js
+++ b/resources/assets/js/server.js
@@ -13,9 +13,11 @@ app.use(bodyParser.json({ limit: '10mb' }));
 /**
  * Simple error handler.
  */
-app.use(function(err, req, res) {
+app.use(function(err, req, res, next) {
   console.error(err.stack);
   res.status(500).send('Something broke!');
+
+  next();
 });
 
 /**


### PR DESCRIPTION
# Changes

Fixes errors that were preventing the server from pre-rendering React views. Babel's Node [require hook](https://babeljs.io/docs/usage/require/) was not configured to use the optional ES7 class properties transformer, so it was failing on trying to parse the component files.

For review: @DoSomething/front-end 
