### PR TITLE
Add Markdown setting type.

### DIFF
--- a/database/migrations/2015_07_29_145513_make_tagline_markdown.php
+++ b/database/migrations/2015_07_29_145513_make_tagline_markdown.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MakeTaglineMarkdown extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+        DB::table('settings')
+            ->where(['key' => 'tagline'])
+            ->update([
+                'type' => 'markdown',
+            ]);
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+        DB::table('settings')
+            ->where(['key' => 'tagline'])
+            ->update([
+                'type' => 'text',
+            ]);
+	}
+
+}

--- a/resources/assets/sass/components/_legal.scss
+++ b/resources/assets/sass/components/_legal.scss
@@ -3,4 +3,9 @@
 .legal {
   color: $gray;
   font-size: $small-font-size;
+
+  a {
+    color: $gray;
+    text-decoration: underline;
+  }
 }

--- a/resources/assets/sass/components/_table.scss
+++ b/resources/assets/sass/components/_table.scss
@@ -14,6 +14,11 @@ table {
     margin-bottom: 0;
   }
 
+  textarea {
+    font-size: $base-font-size;
+    margin-bottom: 0;
+  }
+
   input[type='file'] {
     margin-bottom: 0;
   }

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -9,6 +9,6 @@
         <div id="message"
              class="messages {{ Session::get('message_type', '') }}">{{ Session::get('message') }}</div>
     @else
-        <p class="navigation__tagline">{{ setting('tagline') }}</p>
+        <div class="navigation__tagline">{!! setting('tagline') !!}</div>
     @endif
 </nav>

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -29,6 +29,9 @@
                     <td>
                         @if ($setting->type == 'text')
                             {!! Form::text('value') !!}
+                        @elseif ($setting->type == 'markdown')
+                            {!! Form::textarea('value', null, ['rows' => 3]) !!}
+                            <span class="legal">This setting uses <a href="http://daringfireball.net/projects/markdown/">Markdown</a>.</span>
                         @elseif ($setting->type == 'file')
                             {!! Form::file('value') !!}
                             @if($setting->value)


### PR DESCRIPTION
# Changes

Adds a `markdown` setting type, which gets processed and cached as HTML. This is used in the site tagline setting so that we can include URLs to link to other things! :earth_americas: 

Closes #423. For review: @angaither 
