### PR TITLE
Pre-render the winner detail view on the server.

### DIFF
--- a/app/Http/Controllers/CandidatesController.php
+++ b/app/Http/Controllers/CandidatesController.php
@@ -134,6 +134,11 @@ class CandidatesController extends Controller
     {
         $votes = $candidate->votes();
         $vote_count = $candidate->votes()->count();
+        $winner = Winner::with('candidate')->where('candidate_id', $candidate->id)->first();
+
+        if(setting('show_winners') && $winner) {
+            return view('candidates.show', compact('candidate', 'winner'));
+        }
 
         return view('candidates.show', compact('candidate', 'votes', 'vote_count'));
     }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -33,6 +33,7 @@ import shareLink from './utilities/share-link';
 import CandidateIndex from './components/CandidateIndex';
 import CategoryIndex from './components/CategoryIndex';
 import WinnerIndex from './components/WinnerIndex';
+import WinnerDetailView from './components/WinnerDetailView';
 
 /**
  * Let's go!
@@ -55,5 +56,6 @@ ready(function() {
     'CandidateIndex': CandidateIndex,
     'CategoryIndex': CategoryIndex,
     'WinnerIndex': WinnerIndex,
+    'WinnerDetailView': WinnerDetailView,
   });
 });

--- a/resources/views/candidates/show.blade.php
+++ b/resources/views/candidates/show.blade.php
@@ -3,38 +3,42 @@
 @section('title', $candidate->name)
 @section('meta_title', $candidate->name)
 @section('meta_description', 'Vote for ' . $candidate->name . ' in ' . setting('site_title') . '.')
-@section('meta_image', URL::to($candidate->thumbnail))
+@section('meta_image', url($candidate->thumbnail))
 
 @section('content')
-    <div class="candidate">
-        <div class="candidate__info">
-            <article class="tile -alternate">
-                <a class="wrapper" href="{{ route('candidates.show', [$candidate->slug]) }}">
-                    <div class="tile__meta">
-                        <h1>{{ $candidate->name }}</h1>
+    @if(setting('show_winners'))
+        @react('WinnerDetailView', ['item' => $winner])
+    @else
+        <div class="candidate">
+            <div class="candidate__info">
+                <article class="tile -alternate">
+                    <a class="wrapper" href="{{ route('candidates.show', [$candidate->slug]) }}">
+                        <div class="tile__meta">
+                            <h1>{{ $candidate->name }}</h1>
+                        </div>
+                        <img alt="{{ $candidate->name }}" src="{{ $candidate->thumbnail }}"/>
+                    </a>
+                </article>
+
+                @if($candidate->description)
+                    <p class="candidate__description">{{ $candidate->description }}</p>
+                @endif
+                @if ($candidate->photo_source)
+                    <a href="{{ $candidate->photo_source }}">Photo Credit</a>
+                @endif
+            </div>
+
+            <div class="candidate__actions">
+                @include('votes.form', ['category' => $candidate->category, 'id' => $candidate->id])
+
+                @if(Auth::user() && Auth::user()->admin && $vote_count)
+                    <h4>This candidate has {{ $vote_count }} {{ str_plural('vote', $vote_count)}}.</h4>
+
+                    <div class="form-actions">
+                        <a href="{{ route('candidates.edit', [$candidate->slug]) }}">Edit Candidate</a>
                     </div>
-                    <img alt="{{ $candidate->name }}" src="{{ $candidate->thumbnail }}"/>
-                </a>
-            </article>
-
-            @if($candidate->description)
-                <p class="candidate__description">{{ $candidate->description }}</p>
-            @endif
-            @if ($candidate->photo_source)
-                <a href="{{ $candidate->photo_source }}">Photo Credit</a>
-            @endif
+                @endif
+            </div>
         </div>
-
-        <div class="candidate__actions">
-            @include('votes.form', ['category' => $candidate->category, 'id' => $candidate->id])
-
-            @if(Auth::user() && Auth::user()->admin && $vote_count)
-                <h4>This candidate has {{ $vote_count }} {{ str_plural('vote', $vote_count)}}.</h4>
-
-                <div class="form-actions">
-                    <a href="{{ route('candidates.edit', [$candidate->slug]) }}">Edit Candidate</a>
-                </div>
-            @endif
-        </div>
-    </div>
+    @endif
 @stop


### PR DESCRIPTION
# Changes
- Render the `WinnerDetailView` on the server for users who aren't running JS (who will get a click-through link to the `candidates.show` page, rather than having the drawer open without refresh).

For review: @DoSomething/front-end 
