### PR TITLE
create the reset:app command to reset the app for a new year

### DIFF
--- a/app/Console/Commands/ResetApp.php
+++ b/app/Console/Commands/ResetApp.php
@@ -38,6 +38,11 @@ class ResetApp extends Command {
 	 */
 	public function fire()
 	{
+		if (! $this->confirm('Are you sure you want to delete all votes, users, and winners? [y|N]')) 
+		{
+			return;
+		}
+
 		//remove non-admin users, password reminders, votes, and winners
 		DB::table('votes')->delete();
 		DB::table('users')->where('admin', '=', 0)->delete();

--- a/app/Console/Commands/ResetApp.php
+++ b/app/Console/Commands/ResetApp.php
@@ -3,8 +3,9 @@
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
+use DB;
 
-class ResetAppCommand extends Command {
+class ResetApp extends Command {
 
 	/**
 	 * The console command name.
@@ -38,10 +39,10 @@ class ResetAppCommand extends Command {
 	public function fire()
 	{
 		//remove non-admin users, password reminders, votes, and winners
-		\DB::table('votes')->delete();
-		\DB::table('users')->where('admin', '=', 0)->delete();
-		\DB::table('password_reminders')->delete();
-		\DB::table('winners')->delete();
+		DB::table('votes')->delete();
+		DB::table('users')->where('admin', '=', 0)->delete();
+		DB::table('password_reminders')->delete();
+		DB::table('winners')->delete();
 	}
 
 	/**

--- a/app/Console/Commands/ResetApp.php
+++ b/app/Console/Commands/ResetApp.php
@@ -45,28 +45,4 @@ class ResetApp extends Command {
 		DB::table('winners')->delete();
 	}
 
-	/**
-	 * Get the console command arguments.
-	 *
-	 * @return array
-	 */
-	protected function getArguments()
-	{
-		return [
-			['example', InputArgument::OPTIONAL, 'An example argument.'],
-		];
-	}
-
-	/**
-	 * Get the console command options.
-	 *
-	 * @return array
-	 */
-	protected function getOptions()
-	{
-		return [
-			['example', null, InputOption::VALUE_OPTIONAL, 'An example option.', null],
-		];
-	}
-
 }

--- a/app/Console/Commands/ResetAppCommand.php
+++ b/app/Console/Commands/ResetAppCommand.php
@@ -1,0 +1,71 @@
+<?php namespace VotingApp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class ResetAppCommand extends Command {
+
+	/**
+	 * The console command name.
+	 *
+	 * @var string
+	 */
+	protected $name = 'reset:app';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Reset the app for a new year.';
+
+	/**
+	 * Create a new command instance.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return mixed
+	 */
+	public function fire()
+	{
+		//remove non-admin users, password reminders, votes, and winners
+		\DB::table('votes')->delete();
+		\DB::table('users')->where('admin', '=', 0)->delete();
+		\DB::table('password_reminders')->delete();
+		\DB::table('winners')->delete();
+	}
+
+	/**
+	 * Get the console command arguments.
+	 *
+	 * @return array
+	 */
+	protected function getArguments()
+	{
+		return [
+			['example', InputArgument::OPTIONAL, 'An example argument.'],
+		];
+	}
+
+	/**
+	 * Get the console command options.
+	 *
+	 * @return array
+	 */
+	protected function getOptions()
+	{
+		return [
+			['example', null, InputOption::VALUE_OPTIONAL, 'An example option.', null],
+		];
+	}
+
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -12,7 +12,8 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        '\VotingApp\Console\Commands\CreateAdminUser'
+        '\VotingApp\Console\Commands\CreateAdminUser',
+        '\VotingApp\Console\Commands\ResetAppCommand'
     ];
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,7 +13,7 @@ class Kernel extends ConsoleKernel
      */
     protected $commands = [
         '\VotingApp\Console\Commands\CreateAdminUser',
-        '\VotingApp\Console\Commands\ResetAppCommand'
+        '\VotingApp\Console\Commands\ResetApp'
     ];
 
     /**


### PR DESCRIPTION
fixes #432 

removes password reminders, votes, winners, and users that are not admins

This worked whenever I ran it. I tried to find and follow conventions but let me know if that didn't work out.
