### PR TITLE
Run PHPUnit tests on build.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,4 @@ MAILCHIMP_GROUP_NAME = VotingApp
 MC_OPT_IN_PATH = 555555
 
 STATHAT_APP_NAME=votingapp
+STATHAT_EZ_KEY=email@example.com

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Voting App
+## Voting App [![Wercker](https://img.shields.io/wercker/ci/5463a6bde3d1713625001c35.svg?style=flat-square)](https://app.wercker.com/#applications/5463a6bde3d1713625001c35) [![StyleCI](https://styleci.io/repos/24192462/shield)](https://styleci.io/repos/24192462)
 Voting app for DoSomething.org campaigns, which launched with Celebs Gone Good in December 2014.
 
 ## Getting Started
@@ -8,6 +8,9 @@ Voting app for DoSomething.org campaigns, which launched with Celebs Gone Good i
 4. Run `gulp` to compile front-end assets and watch for changes!
 5. Create a `voting` database in your VM.
 6. Run `php artisan migrate && php artisan db:seed` to get the database set up.
+
+## Tests
+We have a suite of client-side and server-side tests. You can run `npm test` to test client-side code, and `vendor/bin/phpunit` for server-side functional & unit tests. Tests are automatically run on all pull requests.
 
 ## License
 &copy;2015 DoSomething.org. Voting App is free software, and may be redistributed under the terms specified in the [LICENSE](https://github.com/DoSomething/voting-app/blob/master/LICENSE) file. The name and logo for DoSomething.org are trademarks of Do Something, Inc and may not be used without permission.

--- a/wercker.yml
+++ b/wercker.yml
@@ -3,16 +3,29 @@ build:
     # The steps that will be executed on build
     steps:
       - script:
-          name: update node
-          code: |-
-            curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
-            sudo apt-get install -y nodejs
-      - script:
           name: Update apt
           code: sudo apt-get update
       - script:
           name: Install libnotify
           code: sudo apt-get install libnotify-bin
+      - script:
+          name: update node
+          code: |-
+            curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
+            sudo apt-get install -y nodejs
+      - script:
+          name: install mysql
+          code: |-
+            export DEBIAN_FRONTEND=noninteractive
+            sudo -E apt-get -q -y install mysql-server
+            mysqladmin -u root password root
+            mysql -u root -proot -e "CREATE USER 'homestead'@'localhost' IDENTIFIED BY 'secret';"
+            mysql -u root -proot -e "GRANT ALL PRIVILEGES ON *.* TO 'homestead'@'localhost' WITH GRANT OPTION;"
+      - script:
+          name: install php extensions
+          code: |-
+            sudo apt-get install php5-mysql
+            sudo apt-get install php5-gd
       - script:
           name: Update Composer
           code: sudo composer self-update
@@ -24,6 +37,12 @@ build:
             npm config set cache $WERCKER_CACHE_DIR/wercker/npm
             sudo npm install
       - npm-test
+      - script:
+          name: phpunit
+          code: |-
+              cp .env.example .env
+              mysql -u homestead -psecret -e "CREATE DATABASE voting_testing;"
+              vendor/bin/phpunit
       - wercker/bundle-install@1.1.1
       - script:
           name: build assets


### PR DESCRIPTION
#### Changes

PHPUnit tests now run on Wercker builds so we don't accidentally break things. :computer:  :hammer: 

Some more details:
- Our Wercker box, originally created for the scholarship app, does not include MySQL. I [added a build step](https://github.com/DFurnes/voting-app/blob/9e1900187ba5b427776ec2ed11243b2e11da7bea/wercker.yml#L16-L23) to install it and create the same default user as expected in a Homestead environment.
- We also needed to [install the PHP extensions](https://github.com/DFurnes/voting-app/blob/9e1900187ba5b427776ec2ed11243b2e11da7bea/wercker.yml#L24-L28) for MySQL and GD (for image processing when seeding the database.)
- Finally, I [added a step to set up our environment & run the tests](https://github.com/DFurnes/voting-app/blob/9e1900187ba5b427776ec2ed11243b2e11da7bea/wercker.yml#L40-L45). This one should be pretty straightforward!

These steps should probably live in the box so they don't need to be repeated for each build, but that's outside my sphere of influence. :crystal_ball: 
#### How do I test this?

The Wercker build [already did](https://app.wercker.com/#build/563cfa7de143a93e05010311)! Automate all the things! :traffic_light: 

---

For review: @angaither 
