### PR TITLE
Clean up files created during tests before bundling for deploy.

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -43,6 +43,7 @@ build:
               cp .env.example .env
               mysql -u homestead -psecret -e "CREATE DATABASE voting_testing;"
               vendor/bin/phpunit
+              rm -rf public/images
       - script:
           name: build assets
           code: |-


### PR DESCRIPTION
#### Changes

The PHPUnit test suite creates a set of images when seeding the database in `public/images`. Unfortunately, these are then getting bundled up when Wercker saves build output to be used for deploys, and Capistrano is getting unhappy when it finds a folder of :cat:s where it wants to make it's symlink This updates the Wercker build to clean up after itself.

Is this the best way of handling this? We want the rest of the build to be consistent between testing and deploy (Composer and NPM dependencies, built CSS and JS, etc.) so I think this is the right path, but would love any thoughts otherwise!

Closes #444.
#### How should this be manually tested?

When this branch deploys, does it :bomb:? Hopefully not.

---

For review: @angaither @blisteringherb 
