### PR TITLE
Update form & validation logic for #439.

### DIFF
--- a/app/Http/helpers.php
+++ b/app/Http/helpers.php
@@ -32,13 +32,13 @@ function is_international_session()
 
 /**
  * Return if the user's phone should be collected for
- * the current international session's country.
+ * the current session's country.
  *
  * @return bool
  */
-function should_collect_international_phone()
+function should_collect_phone()
 {
-    return in_array(get_country_code(), ['GB', 'BR']);
+    return in_array(get_country_code(), ['MX', 'BR', 'US']);
 }
 
 /**

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -40,18 +40,11 @@ class Registrar implements RegistrarContract
         $rules = [
             'first_name' => ['required'],
             'birthdate' => ['required', 'date', 'before:today'],
+            'email' => ['required', 'email'],
         ];
 
-        if (is_international_session()) {
-            $rules['email'] = ['required', 'email'];
-        }
-
-        if (should_collect_international_phone()) {
+        if (should_collect_phone()) {
             $rules['phone'] = ['phone'];
-        }
-
-        if (is_domestic_session()) {
-            $rules['phone'] = ['required', 'phone'];
         }
 
         return $rules;

--- a/resources/lang/en_BR/forms.php
+++ b/resources/lang/en_BR/forms.php
@@ -11,7 +11,7 @@ return [
     |
     */
 
-    'phone' => 'Mobile Number (optional)',
+    'phone' => 'Mobile Number',
     'phone_placeholder' => '55 55555-5555',
 
 ];

--- a/resources/lang/en_GB/forms.php
+++ b/resources/lang/en_GB/forms.php
@@ -11,7 +11,7 @@ return [
     |
     */
 
-    'phone' => 'Mobile Number (optional)',
+    'phone' => 'Mobile Number',
     'phone_placeholder' => '55555 555 555',
 
 ];

--- a/resources/views/auth/form.blade.php
+++ b/resources/views/auth/form.blade.php
@@ -6,12 +6,10 @@
 {!! Form::label('birthdate', 'Birthdate') !!}
 {!! Form::text('birthdate',  null, ['placeholder' => 'MM/DD/YYYY']) !!}
 
-@if(is_international_session())
-    {!! Form::label('email', 'Email') !!}
-    {!! Form::text('email', null, ['placeholder' => 'you@example.com']) !!}
-@endif
+{!! Form::label('email', 'Email') !!}
+{!! Form::text('email', null, ['placeholder' => 'you@example.com']) !!}
 
-@if(is_domestic_session() || should_collect_international_phone())
-    {!! Form::label('phone', trans('forms.phone')) !!}
+@if(should_collect_phone())
+    {!! Form::label('phone', trans('forms.phone') . ' (optional)') !!}
     {!! Form::text('phone', null, ['placeholder' => trans('forms.phone_placeholder')]) !!}
 @endif

--- a/resources/views/votes/form.blade.php
+++ b/resources/views/votes/form.blade.php
@@ -34,7 +34,7 @@
     <input type="hidden" name="candidate_id" value="{{ $candidate->id or 'CANDIDATE_ID' }}"/>
     {!! Form::submit('Count My Vote', ['class' => 'button -primary']) !!}
 
-    @if(is_domestic_session() || should_collect_international_phone())
+    @if(should_collect_phone())
         <p class="legal">
             By voting you agree to receive future updates from DoSomething.org. Message &amp; data
             rates may apply. Text STOP to opt-out, HELP for help.

--- a/tests/VotingTest.php
+++ b/tests/VotingTest.php
@@ -50,9 +50,34 @@ class VotingTest extends TestCase
     }
 
     /**
-     * Test voting as a US user, where phone number is required.
+     * Test voting as a US user, where phone number is optional.
+     * Should cast vote without a phone number.
+     * @test
      */
-    public function testDomesticVote()
+    public function testUSVoteWithoutPhone()
+    {
+        $url = route('candidates.show', [$this->candidate->slug]);
+
+        $this->inCountry('US')
+            ->visit($url);
+
+        // The cell phone field should be displayed
+        $this->see('Cell Number');
+
+        $this->type('Puppet', 'first_name')
+            ->type('1/1/1992', 'birthdate')
+            ->type('puppet.sloth@example.com', 'email')
+            ->press('Count My Vote');
+
+        $this->see('Thanks, we got that vote!');
+    }
+
+    /**
+     * Test voting as a US user, where phone number is optional.
+     * Should accept the users phone number and cast vote.
+     * @test
+     */
+    public function testUSVoteWithPhone()
     {
         $url = route('candidates.show', [$this->candidate->slug]);
 
@@ -60,6 +85,7 @@ class VotingTest extends TestCase
             ->visit($url)
             ->type('Puppet', 'first_name')
             ->type('1/1/1992', 'birthdate')
+            ->type('puppet.sloth@example.com', 'email')
             ->type('(123) 456-5555', 'phone')
             ->press('Count My Vote');
 
@@ -69,36 +95,23 @@ class VotingTest extends TestCase
     /**
      * Verify that required fields are displayed & validated
      * for international users.
+     * @test
      */
-    public function testInternationalForm()
+    public function testInternationalValidation()
     {
         $url = route('candidates.show', [$this->candidate->slug]);
 
         $this->inCountry('ES')
-            ->visit($url)
-            ->press('Count My Vote');
+            ->visit($url);
 
+        // The "phone" field should not be present.
+        $this->dontSee('Cell Number');
+        $this->dontSee('Mobile Number');
+
+        $this->press('Count My Vote');
 
         $this->see('The first name field is required.');
         $this->see('The birthdate field is required.');
         $this->see('The email field is required.');
-    }
-
-
-    /**
-     * Verify that required fields are displayed & validated
-     * for domestic users.
-     */
-    public function testDomesticForm()
-    {
-        $url = route('candidates.show', [$this->candidate->slug]);
-
-        $this->inCountry('US')
-            ->visit($url)
-            ->press('Count My Vote');
-
-        $this->see('The first name field is required.');
-        $this->see('The birthdate field is required.');
-        $this->see('The phone field is required.');
     }
 }


### PR DESCRIPTION
#### Changes

Updates the form & validation logic as specified in #439. All users are now required to provide an email address, and `US`, `BR`, and `MX` may optionally provide a cell number as well.
#### How should this pull request be tested?

The test suite has been updated to check the new expected behavior (see `VotingTest.php` in the diff). Additionally, functionality can be manually tested on [Cats Gone Good](https://www.catsgonegood.com) by adding `?country_code=XX` to the URL to spoof your country code.
#### Screenshots

Look, screenshots! :mount_fuji:

US users see a cell phone field:
![us](https://cloud.githubusercontent.com/assets/583202/11104187/0c8f32b4-8895-11e5-88f1-150827dd50a7.png)

BR users see a mobile phone field:
![br](https://cloud.githubusercontent.com/assets/583202/11104191/0fd73ed0-8895-11e5-818c-90963cdbc87e.png)

MX users see a mobile phone field:
![mx](https://cloud.githubusercontent.com/assets/583202/11104195/1350d986-8895-11e5-9710-314a62342a98.png)

ES users just get the email field because nobody wants their numbers:
![es](https://cloud.githubusercontent.com/assets/583202/11104197/173f2c8c-8895-11e5-8f44-d43258e2b953.png)

---

For review: @angaither 
