### PR TITLE
Fix issue with 404 when no backgrounds were set.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "classnames": "^2.1.2",
     "dom-delegate": "^2.0.3",
     "express": "^4.12.4",
+    "escope": "3.2.0",
     "html5shiv": "^3.7.3",
     "layzr.js": "^1.1.4",
     "lodash": "^3.9.3",

--- a/resources/views/partials/styles.blade.php
+++ b/resources/views/partials/styles.blade.php
@@ -1,10 +1,12 @@
 <link href="{{ asset('/css/app.css') }}" rel="stylesheet">
 
 <style>
-    html { background-image: url('{{ background('regular', 'none') }}'); }
+    @if(background('regular'))
+    html { background-image: url('{{ background('regular') }}'); }
     @media (min-width: 1200px) {
-        html { background-image: url('{{ background('retina', 'none') }}'); }
+        html { background-image: url('{{ background('retina') }}'); }
     }
+    @endif
 
     @if(setting('ui_tint'))
     h1.highlighted, h2.highlighted, h3.highlighted { background-color: {{ setting('ui_tint') }} !important; }


### PR DESCRIPTION
#### Changes

When no backgrounds are set, it would previously try to load url('none') and get a 404 error. Instead, let's just remove those style rules if they're not necessary.
#### How should this be tested?

Check it out on [Cats Gone Good](http://www.catsgonegood.com) right now. You'll see a 404 error in the web console. Next, check it out post-deploy. You should _not_ see that 404 anymore. :grin: 

---

For review: @weerd 
