### PR TITLE
Provide proper global list/opt-in path.

### DIFF
--- a/app/Listeners/SendFirstVoteMessage.php
+++ b/app/Listeners/SendFirstVoteMessage.php
@@ -57,7 +57,8 @@ class SendFirstVoteMessage
 
             // Provide correct Mobile Opt In ID by country code
             $optInPaths = config('services.message_broker.opt_in_paths');
-            $payload['mobile_opt_in_path_id'] = array_get($optInPaths, $event->user->country_code, 'global');
+            $globalPath = config('services.message_broker.opt_in_paths.global');
+            $payload['mobile_opt_in_path_id'] = array_get($optInPaths, $event->user->country_code, $globalPath);
         }
 
         // Send fields for email communications if provided:
@@ -73,7 +74,8 @@ class SendFirstVoteMessage
 
             // Provide correct MailChimp list ID by country code
             $mailchimpLists = config('services.message_broker.lists');
-            $payload['mailchimp_list_id'] = array_get($mailchimpLists, $event->user->country_code, 'global');
+            $globalList = config('services.message_broker.opt_in_paths.global');
+            $payload['mobile_opt_in_path_id'] = array_get($mailchimpLists, $event->user->country_code, $globalList);
         }
 
         $routingKey = env('VOTE_ROUTING_KEY', 'votingapp.event.vote');


### PR DESCRIPTION
Fixes #460. I was dumb and was just providing the string `global`, rather than the list or opt-in path stored at that key. This fixes it so it does the expected thing. :cactus: 

For review: @angaither 
