### PR TITLE
Accept appropriately localized dates in forms.

### DIFF
--- a/app/LocalizedDate.php
+++ b/app/LocalizedDate.php
@@ -4,11 +4,11 @@ namespace VotingApp;
 
 use Carbon\Carbon;
 
-class LocalizedDate extends Carbon {
-
+class LocalizedDate extends Carbon
+{
     public function __construct($time = null, $timezone = null)
     {
-        if(get_country_code() !== 'US') {
+        if (get_country_code() !== 'US') {
             $time = str_replace('/', '-', $time);
         }
 
@@ -32,12 +32,13 @@ class LocalizedDate extends Carbon {
      * @param $value
      * @return bool
      */
-    public static function validate($value) {
+    public static function validate($value)
+    {
         if ($value instanceof DateTime) {
             return true;
         }
 
-        if(get_country_code() !== 'US') {
+        if (get_country_code() !== 'US') {
             $value = str_replace('/', '-', $value);
         }
 
@@ -49,5 +50,4 @@ class LocalizedDate extends Carbon {
 
         return checkdate($date['month'], $date['day'], $date['year']);
     }
-
 }

--- a/app/LocalizedDate.php
+++ b/app/LocalizedDate.php
@@ -21,7 +21,7 @@ class LocalizedDate extends Carbon
     public static function getExpectedFormat($countryCode = null)
     {
         // Get country code from current session if not provided
-        if($countryCode === null) {
+        if ($countryCode === null) {
             $countryCode = get_country_code();
         }
 
@@ -40,7 +40,7 @@ class LocalizedDate extends Carbon
     public static function normalize($time, $countryCode = null)
     {
         // Get country code from current session if not provided
-        if($countryCode === null) {
+        if ($countryCode === null) {
             $countryCode = get_country_code();
         }
 

--- a/app/LocalizedDate.php
+++ b/app/LocalizedDate.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace VotingApp;
+
+use Carbon\Carbon;
+
+class LocalizedDate extends Carbon {
+
+    public function __construct($time = null, $timezone = null)
+    {
+        if(get_country_code() !== 'US') {
+            $time = str_replace('/', '-', $time);
+        }
+
+        parent::__construct($time, $timezone);
+    }
+
+    /**
+     * Get expected date format by current session's country code.
+     *
+     * @return string
+     */
+    public static function getExpectedFormat()
+    {
+        return get_country_code() === 'US' ? 'MM/DD/YYYY' : 'DD/MM/YYYY';
+    }
+
+    /**
+     * Validate a given date. Based on Laravel's built-in `date` validator.
+     * @see \Illuminate\Validation\Validator validateDate()
+     *
+     * @param $value
+     * @return bool
+     */
+    public static function validate($value) {
+        if ($value instanceof DateTime) {
+            return true;
+        }
+
+        if(get_country_code() !== 'US') {
+            $value = str_replace('/', '-', $value);
+        }
+
+        if (strtotime($value) === false) {
+            return false;
+        }
+
+        $date = date_parse($value);
+
+        return checkdate($date['month'], $date['day'], $date['year']);
+    }
+
+}

--- a/app/LocalizedDate.php
+++ b/app/LocalizedDate.php
@@ -6,41 +6,81 @@ use Carbon\Carbon;
 
 class LocalizedDate extends Carbon
 {
-    public function __construct($time = null, $timezone = null)
+    public function __construct($time = null, $countryCode = null, $timezone = null)
     {
-        if (get_country_code() !== 'US') {
-            $time = str_replace('/', '-', $time);
-        }
-
+        $time = static::normalize($time, $countryCode);
         parent::__construct($time, $timezone);
     }
 
     /**
      * Get expected date format by current session's country code.
      *
+     * @param string $countryCode - Optionally, override country code
      * @return string
      */
-    public static function getExpectedFormat()
+    public static function getExpectedFormat($countryCode = null)
     {
-        return get_country_code() === 'US' ? 'MM/DD/YYYY' : 'DD/MM/YYYY';
+        // Get country code from current session if not provided
+        if($countryCode === null) {
+            $countryCode = get_country_code();
+        }
+
+        return $countryCode === 'US' ? 'MM/DD/YYYY' : 'DD/MM/YYYY';
+    }
+
+    /**
+     * Normalize a given time by the application's current
+     * country code. Parses MM/DD/YYYY formatted dates in US,
+     * and DD/MM/YYYY elsewhere.
+     *
+     * @param string $time - Date (to be passed to DateTime constructor)
+     * @param string $countryCode - Optionally, override country code
+     * @return string
+     */
+    public static function normalize($time, $countryCode = null)
+    {
+        // Get country code from current session if not provided
+        if($countryCode === null) {
+            $countryCode = get_country_code();
+        }
+
+        // Force '/' separators, which indicate MM/DD/YYYY in the US, and '-' separators
+        // in other countries, which indicates DD-MM-YYYY.
+        //
+        // From the PHP documentation:
+        //
+        //     "Dates in the m/d/y or d-m-y formats are disambiguated by looking at the
+        //     separator between the various components: if the separator is a slash (/),
+        //     then the American m/d/y is assumed; whereas if the separator is a dash (-)
+        //     or a dot (.), then the European d-m-y format is assumed."
+        //
+        // @see: http://php.net/manual/en/function.strtotime.php
+        if ($countryCode !== 'US') {
+            $time = str_replace('/', '-', $time);
+        } else {
+            $time = str_replace('-', '/', $time);
+            $time = str_replace('.', '/', $time);
+        }
+
+        return $time;
     }
 
     /**
      * Validate a given date. Based on Laravel's built-in `date` validator.
      * @see \Illuminate\Validation\Validator validateDate()
      *
-     * @param $value
+     * @param string $value - Date (to be validated)
+     * @param string $countryCode - Optionally, override country code
      * @return bool
      */
-    public static function validate($value)
+    public static function validate($value, $countryCode = null)
     {
         if ($value instanceof DateTime) {
             return true;
         }
 
-        if (get_country_code() !== 'US') {
-            $value = str_replace('/', '-', $value);
-        }
+        // Before validating, normalize strings by country code.
+        $value = static::normalize($value, $countryCode);
 
         if (strtotime($value) === false) {
             return false;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Auth\Passwords\CanResetPassword;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
+use VotingApp\LocalizedDate;
 
 class User extends Model implements AuthenticatableContract, CanResetPasswordContract
 {
@@ -50,7 +51,8 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
      */
     public function setBirthdateAttribute($birthdate)
     {
-        $this->attributes['birthdate'] = date('Y-m-d', (strtotime($birthdate)));
+        $formatted = LocalizedDate::parse($birthdate)->format('Y-m-d');
+        $this->attributes['birthdate'] = $formatted;
     }
 
     /**

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -23,15 +23,21 @@ class ValidationServiceProvider extends ServiceProvider
     {
         $this->validator = $this->app->make('validator');
 
+        // Add custom validator for phone numbers
         $this->validator->extend('phone', function ($attribute, $value, $parameters) {
             $phoneRegex = '/^(?:\+?([0-9]{1,3})([\-\s\.]{1})?)?\(?([0-9]{3})\)?(?:[\-\s\.]{1})?([0-9]{3})(?:[\-\s\.]{1})?([0-9]{4})/';
 
             return preg_match($phoneRegex, $value);
         }, 'The :attribute must be a valid phone number.');
 
+        // Add custom validator for localized date (e.g. `MM/DD/YYYY` or `DD/MM/YYYY`).
         $this->validator->extend('localized_date', function ($attribute, $value, $parameters) {
             return LocalizedDate::validate($value);
-        }, 'Enter your :attribute '.LocalizedDate::getExpectedFormat().'.');
+        }, 'Enter your :attribute in :expected_date_format.');
+
+        $this->validator->replacer('localized_date', function ($message, $attribute, $rule, $parameters) {
+            return str_replace(':expected_date_format', LocalizedDate::getExpectedFormat(), $message);
+        });
     }
 
     /**

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -3,6 +3,7 @@
 namespace VotingApp\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use VotingApp\LocalizedDate;
 
 class ValidationServiceProvider extends ServiceProvider
 {
@@ -27,6 +28,10 @@ class ValidationServiceProvider extends ServiceProvider
 
             return preg_match($phoneRegex, $value);
         }, 'The :attribute must be a valid phone number.');
+
+        $this->validator->extend('localized_date', function ($attribute, $value, $parameters) {
+            return LocalizedDate::validate($value);
+        }, 'Enter your :attribute '.LocalizedDate::getExpectedFormat().'.');
     }
 
     /**

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -39,7 +39,7 @@ class Registrar implements RegistrarContract
     {
         $rules = [
             'first_name' => ['required'],
-            'birthdate' => ['required', 'date', 'before:today'],
+            'birthdate' => ['required', 'localized_date', 'before:today'],
             'email' => ['required', 'email'],
         ];
 

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -31,7 +31,7 @@ class UsersTableSeeder extends Seeder
             User::create([
                 'first_name' => $faker->firstName,
                 'email' => $faker->unique()->safeEmail,
-                'birthdate' => $faker->date($format = 'm/d/Y', $max = 'now'),
+                'birthdate' => $faker->date($format = 'd-m-Y', $max = 'now'),
                 'country_code' => $faker->countryCode,
             ]);
         }
@@ -40,7 +40,7 @@ class UsersTableSeeder extends Seeder
             User::create([
                 'first_name' => $faker->firstName,
                 'phone' => $faker->unique()->phoneNumber,
-                'birthdate' => $faker->date($format = 'm/d/Y', $max = 'now'),
+                'birthdate' => $faker->date($format = 'd-m-Y', $max = 'now'),
                 'country_code' => 'US',
             ]);
         }

--- a/resources/views/auth/form.blade.php
+++ b/resources/views/auth/form.blade.php
@@ -4,7 +4,7 @@
 {!! Form::text('first_name', null, ['placeholder' => 'What\'s your name?']) !!}
 
 {!! Form::label('birthdate', 'Birthdate') !!}
-{!! Form::text('birthdate',  null, ['placeholder' => 'MM/DD/YYYY']) !!}
+{!! Form::text('birthdate',  null, ['placeholder' => \VotingApp\LocalizedDate::getExpectedFormat()]) !!}
 
 {!! Form::label('email', 'Email') !!}
 {!! Form::text('email', null, ['placeholder' => 'you@example.com']) !!}

--- a/tests/LocalizedDateTest.php
+++ b/tests/LocalizedDateTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use VotingApp\LocalizedDate;
+
+class LocalizedDateTest extends TestCase
+{
+
+    /**
+     * Verify that US-style MM/DD/YYYY dates can be parsed.
+     * @test
+     */
+    public function testMMDDYYYYDates()
+    {
+        $date = new LocalizedDate('1/2/1990', 'US');
+
+        $this->assertInstanceOf('VotingApp\LocalizedDate', $date);
+
+        $this->assertSame(631238400, $date->getTimestamp());
+    }
+
+    /**
+     * Verify that international-style DD/MM/YYYY dates can be parsed.
+     * @test
+     */
+    public function testDDMMYYYYDates()
+    {
+        $date = new LocalizedDate('2/1/1990', 'GB');
+
+        $this->assertInstanceOf('VotingApp\LocalizedDate', $date);
+
+        $this->assertSame(631238400, $date->getTimestamp());
+    }
+
+    /**
+     * Test that other non-standard strtotime() formats
+     * still work as expected.
+     * @test
+     */
+    public function testOtherFormats()
+    {
+        $date = new LocalizedDate('January 2nd 1990', 'US');
+        $this->assertSame(631238400, $date->getTimestamp());
+
+        $date2 = new LocalizedDate('January 2, 1990', 'US');
+        $this->assertSame(631238400, $date2->getTimestamp());
+
+        $date3 = new LocalizedDate('2 January 1990', 'US');
+        $this->assertSame(631238400, $date3->getTimestamp());
+    }
+
+    /**
+     * Test that given strings are validated/invalidated.
+     * @test
+     */
+    public function testValidate()
+    {
+        $this->assertTrue(LocalizedDate::validate('1/25/1990', 'US'));
+
+        $this->assertTrue(LocalizedDate::validate('1-25-1990', 'US'));
+
+        $this->assertTrue(LocalizedDate::validate('1.25.1990', 'US'));
+
+        $this->assertTrue(LocalizedDate::validate('25/1/1990', 'GB'));
+
+        $this->assertTrue(LocalizedDate::validate('25-1-1990', 'GB'));
+
+        $this->assertFalse(LocalizedDate::validate('25/1/1990', 'US'));
+
+        $this->assertTrue(LocalizedDate::validate('January 2nd 1990', 'US'));
+    }
+
+}

--- a/tests/LocalizedDateTest.php
+++ b/tests/LocalizedDateTest.php
@@ -4,7 +4,6 @@ use VotingApp\LocalizedDate;
 
 class LocalizedDateTest extends TestCase
 {
-
     /**
      * Verify that US-style MM/DD/YYYY dates can be parsed.
      * @test
@@ -68,5 +67,4 @@ class LocalizedDateTest extends TestCase
 
         $this->assertTrue(LocalizedDate::validate('January 2nd 1990', 'US'));
     }
-
 }

--- a/tests/VotingTest.php
+++ b/tests/VotingTest.php
@@ -22,7 +22,8 @@ class VotingTest extends TestCase
      */
     public function testSubmitVote()
     {
-        $this->visit(route('candidates.show', [$this->candidate->slug]))
+        $this->inCountry('US')
+            ->visit(route('candidates.show', [$this->candidate->slug]))
             ->type('Puppet', 'first_name')
             ->type('1/2/1990', 'birthdate')
             ->type('test-example-user@example.com', 'email')
@@ -178,7 +179,7 @@ class VotingTest extends TestCase
         $this->inCountry('ES')
             ->visit($url)
             ->type('Puppet', 'first_name')
-            ->type('02-01-1990', 'birthdate')
+            ->type('25/01/1990', 'birthdate') // DD/MM/YYYY
             ->type('marioneta.pereza@example.com', 'email')
             ->press('Count My Vote');
 
@@ -187,7 +188,7 @@ class VotingTest extends TestCase
         $this->seeInDatabase('users', [
             'id' => $user->id,
             'first_name' => 'Puppet',
-            'birthdate' => '1990-01-02',
+            'birthdate' => '1990-01-25',
         ]);
 
         $this->see('Thanks, we got that vote!');


### PR DESCRIPTION
#### Changes

Accept appropriately localized dates (e.g. `DD/MM/YYYY` for international users, and `MM/DD/YYYY` for US users). We do this by the extremely scientific :microscope: method of re-formatting `DD/MM/YYYY` dates to use dashes which indicates that format to PHP's `DateTime` constructor.

Closes #461.
#### How do I test this?

Unit tests have been updated, so those should be :green_heart:. If you pull this branch to your local, you should see `DD/MM/YYYY` dates unless you set your country code to `US`.
#### Open Questions

I put my `LocalizedDate` helper class in the root `app/` directory... is there a more appropriate area we should be holding small helper object classes? Perhaps `app/Helpers`?

---

For review: @angaither 
