### PR TITLE
Save country code in memory rather than writing to session.

### DIFF
--- a/app/Http/Middleware/SetCountryCodeFromHeader.php
+++ b/app/Http/Middleware/SetCountryCodeFromHeader.php
@@ -15,15 +15,19 @@ class SetCountryCodeFromHeader
      */
     public function handle($request, Closure $next)
     {
-        // Save country code in session if not set
-        if (! $request->session()->has('country_code')) {
-            $request->session()->put('country_code', $this->getCountryCode($request));
-        };
+        $countryCode = $this->getCountryCode($request);
 
         // Allow overriding country via query string, for debugging
         if ($queryOverride = $request->get('country_code')) {
             $request->session()->put('country_code', $queryOverride);
         }
+
+        if ($request->hasSession() && $request->session()->has('country_code')) {
+            $countryCode = $request->session()->get('country_code');
+        }
+
+        // Set country code for this request
+        config()->set('app.country_code', $countryCode);
 
         return $next($request);
     }

--- a/app/Http/helpers.php
+++ b/app/Http/helpers.php
@@ -1,13 +1,14 @@
 <?php
 
 /**
- * Return contents of Fastly's GeoIP country code header.
+ * Return current country code by Fastly header or session override.
+ * @see: \VotingApp\Http\Middleware\SetCountryCodeFromHeader
  *
  * @return string|null - Country Code, or null if header is not set.
  */
 function get_country_code()
 {
-    return session()->get('country_code');
+    return config('app.country_code');
 }
 
 /**

--- a/config/app.php
+++ b/config/app.php
@@ -43,6 +43,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Country Code Configuration
+    |--------------------------------------------------------------------------
+    |
+    | We store the current request's country code as a config setting, since it
+    | is stored in memory, rather than writing to the session.
+    |
+    | We set a default "catchall" country code of "XX" if nothing else is set.
+    |
+    */
+    'country_code' => 'XX',
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Locale Configuration
     |--------------------------------------------------------------------------
     |

--- a/tests/VotingTest.php
+++ b/tests/VotingTest.php
@@ -102,7 +102,9 @@ class VotingTest extends TestCase
     {
         $url = route('candidates.show', [$this->candidate->slug]);
 
-        $this->inCountry('US')
+        $this->inCountry('GB')
+            ->visit($url)
+            ->inCountry('US')
             ->visit($url)
             ->type('Puppet', 'first_name')
             ->type('1/2/1992', 'birthdate')


### PR DESCRIPTION
#### Changes

A potential tweak to address country code issues... trying storing the country in memory rather than saving to the session. I don't think this is _the_ issue (since the same codebase worked fine in AGG), but does avoid a corner case that was showing up during testing where country code would be stored in the session and not updated when testers switched to a new remote proxy via TorGuard.
#### How do I review this?

Automated tests should still pass. Let's check thoroughly on Cats Gone Good as well. :cat2: 

---

For review/thoughts: @angaither 
