### PR TITLE
Add logging for request details.

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -20,6 +20,7 @@ class Kernel extends HttpKernel
         'VotingApp\Http\Middleware\VerifyCsrfToken',
         'VotingApp\Http\Middleware\SetCountryCodeFromHeader',
         'VotingApp\Http\Middleware\SetLanguageFromHeader',
+        'VotingApp\Http\Middleware\LogRequestDetails',
     ];
 
     /**

--- a/app/Http/Middleware/LogRequestDetails.php
+++ b/app/Http/Middleware/LogRequestDetails.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace VotingApp\Http\Middleware;
+
+use Closure;
+
+class LogRequestDetails
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if (env('LOG_REQUEST_DETAILS')) {
+            logger('Received request with country header "'.get_country_code().'".', [
+                'HTTP_X_FASTLY_COUNTRY_CODE' => $request->server('HTTP_X_FASTLY_COUNTRY_CODE', null),
+                'IP' => $request->ip(),
+                'url' => $request->url(),
+                'method' => $request->method(),
+            ]);
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
#### Changes

Log all the ~~things~~ requests. If `LOG_REQUEST_DETAILS` is toggled on, then log details for every single request. Maybe we'll find some clues in there. :deciduous_tree: :mag: 
#### Examples

```
# A bad request (taken from my local, where no Fastly exists...)
[2015-12-02 16:15:35] local.DEBUG: Received request with country header "". {"HTTP_X_FASTLY_COUNTRY_CODE":null,"IP":"10.0.2.2","url":"http://voting-app.dev:8000","method":"GET"} 

# A good request (taken from the simulated headers in the PHPUnit test suite):
[2015-12-02 16:15:35] local.DEBUG: Received request with country header "". {"HTTP_X_FASTLY_COUNTRY_CODE":null,"IP":"10.0.2.2","url":"http://voting-app.dev:8000","method":"GET"} 
```

For review: @angaither @sheyd 
