### PR TITLE
Fix Northstar connection issues

### DIFF
--- a/app/Services/Northstar.php
+++ b/app/Services/Northstar.php
@@ -111,7 +111,7 @@ class Northstar
         $payload = ['interests' => $candidate->category->slug];
 
         try {
-            $response = $this->client->put('users/'.e($user->northstar_id), ['body' => json_encode($payload)]);
+            $response = $this->client->put('users/_id/'.e($user->northstar_id), ['body' => json_encode($payload)]);
 
             return $response->getStatusCode() === 200;
         } catch (Exception $e) {

--- a/app/Services/Northstar.php
+++ b/app/Services/Northstar.php
@@ -70,6 +70,7 @@ class Northstar
             'first_name' => $user->first_name,
             'birthdate' => $user->birthdate,
             config('services.northstar.id_field') => $user->id,
+            'source' => env('NORTHSTAR_SOURCE', 'votingapp'),
         ];
 
         if ($user->phone) {

--- a/app/Services/Northstar.php
+++ b/app/Services/Northstar.php
@@ -91,8 +91,6 @@ class Northstar
             return $json['data']['_id'];
         } catch (Exception $e) {
             $this->logException($e);
-
-            return;
         }
     }
 


### PR DESCRIPTION
#### Changes

Fixes #487 by using the new `PUT /users` endpoint. Also adds a new environment variable to be passed as a source for newly created users. Example "new" user created on my local:

![screen shot 2015-12-02 at 2 15 27 pm](https://cloud.githubusercontent.com/assets/583202/11541247/2c074d3c-98ff-11e5-8e98-ee5f3bb0ddd0.png)
#### Known Issues

A `500` error occurs on Northstar if trying to "create" a user that already exists, since existing users require a password to update their details. This is _probably_ best for now, since we can't guarantee that this data is really "authorized". That being said, we may want to handle this a bit more gracefully over there. (VotingApp handles the exception and logs it, but continues to function normally.)
#### How should this be tested?

Feel free to manually test by adding Northstar to your `/etc/hosts` on Homestead... I had to add `10.0.2.2  northstar.dev` before it would correctly connect... YMMV. Of course, automated tests should continue to pass as well (although we don't have any specific coverage for the Northstar functionality).

---

For review: @angaither 
/cc @jonuy 
