### PR TITLE
Potentially fix for occasionally mangled tweets

### DIFF
--- a/app/Http/helpers.php
+++ b/app/Http/helpers.php
@@ -66,7 +66,7 @@ function tweet_intent($text, $url, $twitter = null)
         $text = str_replace('TWITTER_NAME', $twitter, $text);
     }
 
-    return 'https://twitter.com/intent/tweet?text='.urlencode($text).'&url='.urlencode($url);
+    return 'https://twitter.com/intent/tweet?text='.rawurlencode($text).'&url='.rawurlencode($url);
 }
 
 /**


### PR DESCRIPTION
#### Changes

Potentially fixes the occasionally mangled tweets seen in #493. According to [this Stack Overflow answer](http://stackoverflow.com/a/996161), `urlencode` is intended for legacy systems. Both _should_ work, but perhaps somehow Twitter is sometimes not correctly interpreting the '+' delimited strings that `urlencode` creates...

`rawurlencode` encodes spaces as the ol' `%20` instead, which we may have more consistent luck with? Only time will tell, since both functions work correctly from my own testing.
#### How do I test this?

Once this deploys, try sharing some cats. You should see correctly parsed tweet text in the dialog box.

---

For review: @angaither 
