### PR TITLE
Don't send the full array in the payload.

### DIFF
--- a/app/Listeners/SendFirstVoteMessage.php
+++ b/app/Listeners/SendFirstVoteMessage.php
@@ -27,7 +27,7 @@ class SendFirstVoteMessage
      */
     public function handle(UserCastFirstVote $event)
     {
-        $country_code_or_global = !empty($event->user->country_code) ? $event->user->country_code : 'global';
+        $country_code_or_global = ! empty($event->user->country_code) ? $event->user->country_code : 'global';
 
         $payload = [
             'first_name' => $event->user->first_name,

--- a/app/Listeners/SendFirstVoteMessage.php
+++ b/app/Listeners/SendFirstVoteMessage.php
@@ -27,6 +27,8 @@ class SendFirstVoteMessage
      */
     public function handle(UserCastFirstVote $event)
     {
+        $country_code_or_global = !empty($event->user->country_code) ? $event->user->country_code : 'global';
+
         $payload = [
             'first_name' => $event->user->first_name,
             'birthdate_timestamp' => strtotime($event->user->birthdate), // Message Broker expects UNIX timestamp
@@ -58,14 +60,14 @@ class SendFirstVoteMessage
             // Provide correct Mobile Opt In ID by country code
             $optInPaths = config('services.message_broker.opt_in_paths');
             $globalPath = config('services.message_broker.opt_in_paths.global');
-            $payload['mobile_opt_in_path_id'] = array_get($optInPaths, $event->user->country_code, $globalPath);
+            $payload['mobile_opt_in_path_id'] = array_get($optInPaths, $country_code_or_global, $globalPath);
         }
 
         // Send fields for email communications if provided:
         if ($event->user->email) {
             $payload['email'] = $event->user->email;
             $payload['subscribed'] = 1;
-            $payload['email_template'] = env('VOTE_TEMPLATE', 'mb-votingapp-vote').'-'.$event->user->country_code;
+            $payload['email_template'] = env('VOTE_TEMPLATE', 'mb-votingapp-vote').'-'.$country_code_or_global;
             $payload['email_tags'] = [
                 env('APP_NAME_TAG', 'votingapp'),
                 $event->candidate->id,
@@ -75,7 +77,7 @@ class SendFirstVoteMessage
             // Provide correct MailChimp list ID by country code
             $mailchimpLists = config('services.message_broker.lists');
             $globalList = config('services.message_broker.lists.global');
-            $payload['mailchimp_list_id'] = array_get($mailchimpLists, $event->user->country_code, $globalList);
+            $payload['mailchimp_list_id'] = array_get($mailchimpLists, $country_code_or_global, $globalList);
         }
 
         $routingKey = env('VOTE_ROUTING_KEY', 'votingapp.event.vote');


### PR DESCRIPTION
#### Changes

Fixes #494. Laravel tries to be clever by returning the whole given array if the `$key` is null... since we're still having the problems in #482, let's make sure we don't let this trip us up.
#### How should this be tested?

I tested on my local by `dd`ing the payload in the Message Broker class. Here's what it looks like now:

![screen shot 2015-12-11 at 11 08 21 am](https://cloud.githubusercontent.com/assets/583202/11748781/fac6b078-9ff7-11e5-9687-44c155f65243.png)

Much better [than before](https://cloud.githubusercontent.com/assets/583202/11748802/1d36aa0a-9ff8-11e5-8560-24df5f38fca5.png).

---

For review: @angaither 
/cc @DeeZone 
