### PR TITLE
admins can toggle titles showing on tiles

### DIFF
--- a/database/migrations/2016_03_31_195317_add_show_title_setting.php
+++ b/database/migrations/2016_03_31_195317_add_show_title_setting.php
@@ -17,7 +17,8 @@ class AddShowTitleSetting extends Migration
             'type' => 'boolean',
             'value' => '1',
             'description' => 'True if the title is to be shown on the tiles',
-        ]);    }
+        ]);
+    }
 
     /**
      * Reverse the migrations.

--- a/database/migrations/2016_03_31_195317_add_show_title_setting.php
+++ b/database/migrations/2016_03_31_195317_add_show_title_setting.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddShowTitleSetting extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::table('settings')->insert([
+            'key' => 'show_title',
+            'type' => 'boolean',
+            'value' => '1',
+            'description' => 'True if the title is to be shown on the tiles',
+        ]);    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::table('settings')->delete(['key' => 'show_title']);
+    }
+}

--- a/resources/views/partials/styles.blade.php
+++ b/resources/views/partials/styles.blade.php
@@ -36,4 +36,8 @@
     @if(!setting('enable_voting') || !setting('vote_button'))
     .tile__action { display: none !important; }
     @endif
+
+    @if(!setting('show_title'))
+    .tile__meta { display: none !important; }
+    @endif
 </style>


### PR DESCRIPTION
- admins can now toggle whether or not they want titles to appear on the candidates
- includes database migrate to add the new setting of "show title"
### Issues:

Fixes #500
