### PR TITLE
set max height for sponsor logo

### DIFF
--- a/resources/assets/sass/modules/_figure.scss
+++ b/resources/assets/sass/modules/_figure.scss
@@ -106,6 +106,7 @@
 
   img {
     margin: 0 auto;
+    max-width: 50px;
   }
 }
 


### PR DESCRIPTION
- sponsor logo has a max height of 50px now

cc: @mikefantini , @namimody 
