### PR TITLE
Only send country codes that we have lists registered for.

### DIFF
--- a/app/Http/helpers.php
+++ b/app/Http/helpers.php
@@ -12,6 +12,20 @@ function get_country_code()
 }
 
 /**
+ * Does this country have a template specified in Message Broker? If so, return
+ * the code. If not, return the "global" placeholder code for a fallback template.
+ *
+ * @param string - country code
+ * @return string
+ */
+function transactional_country_code($country_code)
+{
+    $allowed = array_filter(config('services.message_broker.lists'));
+
+    return array_key_exists($country_code, $allowed) ? $country_code : 'XG';
+}
+
+/**
  * Return if the user is a domestic (US) session.
  *
  * @return bool


### PR DESCRIPTION
#### Changes

Closes #525.

This pull request adds a new `transactional_country_code` helper method to _only_ send template names for countries with non-empty MailChimp list IDs set in the instance's environment variables (e.g. if we have list IDs set for US and MX, we'd _only_ ever send `mb-votingapp-vote-US`, `mb-votingapp-vote-MX`, and use `mb-votingapp-vote-XG` for _any_ other value even if it's a real country code).
#### How should this be tested?

I'd like to make some tests for the transnational payload, but I think I'd need to refactor things a bit to allow that payload to be inspected before sending it off. So for now, 👓 👀 ⁉️!

---

For review: @katiecrane @angaither 
