### PR TITLE
Fix issue with picking the proper opt-in path or list ID

### DIFF
--- a/app/Http/helpers.php
+++ b/app/Http/helpers.php
@@ -26,6 +26,22 @@ function transactional_country_code($country_code)
 }
 
 /**
+ * Try to get a value from the config array at the given path, with an optional
+ * fallback path if the desired path is falsy (e.g. empty string or null).
+ *
+ * @param $configPath - Dot notation path for the config array
+ * @param $key - Desired key
+ * @param $fallbackKey - Fallback key, if desired value is falsy
+ */
+function filtered_config($configPath, $key, $fallbackKey)
+{
+    $filteredConfig = array_filter(config($configPath));
+    $key = array_key_exists($key, $filteredConfig) ? $key : $fallbackKey;
+
+    return $filteredConfig[$key];
+}
+
+/**
  * Return if the user is a domestic (US) session.
  *
  * @return bool

--- a/app/Listeners/SendFirstVoteMessage.php
+++ b/app/Listeners/SendFirstVoteMessage.php
@@ -55,10 +55,8 @@ class SendFirstVoteMessage
                 'GENDER_'.$event->candidate->gender,
             ];
 
-            // Provide correct Mobile Opt In ID by country code
-            $optInPaths = config('services.message_broker.opt_in_paths');
-            $globalPath = config('services.message_broker.opt_in_paths.XG');
-            $payload['mobile_opt_in_path_id'] = array_get($optInPaths, $event->user->country_code, $globalPath);
+            // Provide Mobile Opt In Path for the user's country code, or global opt-in path if not set.
+            $payload['mobile_opt_in_path_id'] = filtered_config('services.message_broker.opt_in_paths', $event->user->country_code, 'XG');
         }
 
         // Send fields for email communications if provided:
@@ -72,10 +70,8 @@ class SendFirstVoteMessage
                 'GENDER_'.$event->candidate->gender,
             ];
 
-            // Provide correct MailChimp list ID by country code
-            $mailchimpLists = config('services.message_broker.lists');
-            $globalList = config('services.message_broker.lists.XG');
-            $payload['mailchimp_list_id'] = array_get($mailchimpLists, $event->user->country_code, $globalList);
+            // Provide MailChimp list for the user's country code, or global list if not set.
+            $payload['mailchimp_list_id'] = filtered_config('services.message_broker.lists', $event->user->country_code, 'XG');
         }
 
         $routingKey = env('VOTE_ROUTING_KEY', 'votingapp.event.vote');


### PR DESCRIPTION
#### Changes

This PR fixes an issue with picking the proper opt-in path or list ID. The `array_get` method, while like _almost_ exactly what we needed, returns the whole array if the given key is null (which is like not at all what we'd ever want). I had also forgotten to filter out "falsy" values from the config array.

---

For review: @angaither @katiecrane 
