### PR TITLE
Only hide vote button if 'vote_button' setting is false.

### DIFF
--- a/resources/views/partials/styles.blade.php
+++ b/resources/views/partials/styles.blade.php
@@ -33,7 +33,7 @@
     }
     @endif
 
-    @if(!setting('enable_voting') || !setting('vote_button'))
+    @if(!setting('vote_button'))
     .tile__action { display: none !important; }
     @endif
 


### PR DESCRIPTION
#### Changes

Fixes #531. This toggles vote buttons _only_ based on the `vote_button` setting, rather than overriding them to be hidden any time voting is disabled as well (since we typically want voting to be disabled during the closed state when winners are displayed, but _also_ want those winners to have "vote" buttons with their rankings).

![screen shot 2016-05-31 at 3 00 11 pm](https://cloud.githubusercontent.com/assets/583202/15686980/82e26f72-2740-11e6-8247-7621eafbfb21.png)

---

For review: @angaither 
