### PR TITLE
Adds metatag for twitter cards

### DIFF
--- a/resources/views/partials/metadata.blade.php
+++ b/resources/views/partials/metadata.blade.php
@@ -4,6 +4,7 @@
       content="@yield('meta_description', 'Vote for your favorite ' . setting('candidate_type') . ' who has done kickass things in the world this year.')"/>
 
 {{-- Twitter --}}
+<meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@dosomething"/>
 <meta name="twitter:creator" content="@dosomething"/>
 <meta name="twitter:url" content="{{ URL::current() }}"/>


### PR DESCRIPTION
Code referenced from here: https://dev.twitter.com/cards/types/summary-large-image

Not sure how to test it locally, Twitter has this fancy testing tool https://cards-dev.twitter.com/validator

but i have to supply a URL its capable of reaching. i guess we can do it on staging after its merged?
