### PR TITLE
Setting Northstar ID to null instead of "CONFLICT"

### DIFF
--- a/app/Http/Controllers/VotesController.php
+++ b/app/Http/Controllers/VotesController.php
@@ -9,7 +9,7 @@ use VotingApp\Events\UserCastFirstVote;
 use VotingApp\Http\Requests\VoteRequest;
 use VotingApp\Models\Candidate;
 use VotingApp\Models\Vote;
-use Northstar;
+use DoSomething\Gateway\Northstar;
 
 class VotesController extends Controller
 {
@@ -73,8 +73,8 @@ class VotesController extends Controller
         }
 
         // If we have a valid Northstar ID, let's try to update their profile with their vote.
-        if (array_has(['CONFLICT', 'ERROR', 'ERROR_CONNECTION'], $user->northstar_id)) {
-            Northstar::updateUser($user->northstar_id, [
+        if ($user->northstar_id !== null) {
+            gateway('northstar')->updateUser($user->northstar_id, [
                 'interests' => [
                     $vote->candidate->name,
                 ],

--- a/app/Http/Controllers/VotesController.php
+++ b/app/Http/Controllers/VotesController.php
@@ -9,7 +9,6 @@ use VotingApp\Events\UserCastFirstVote;
 use VotingApp\Http\Requests\VoteRequest;
 use VotingApp\Models\Candidate;
 use VotingApp\Models\Vote;
-use DoSomething\Gateway\Northstar;
 
 class VotesController extends Controller
 {

--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -88,14 +88,14 @@ class Registrar implements RegistrarContract
                 $northstar_user = gateway('northstar')->createUser($payload);
                 $user->northstar_id = $northstar_user->id;
             } catch (ValidationException $e) {
-                // If this conflicts in Northstar, mark "CONFLICT" rather than
+                // If this conflicts in Northstar, mark null rather than
                 // bothering the user with the specific issue & preventing the vote.
-                $user->northstar_id = 'CONFLICT';
+                $user->northstar_id = null;
             } catch (APIException $e) {
                 logger('northstar exception', ['error' => $e->getMessage()]);
-                $user->northstar_id = 'ERROR';
+                $user->northstar_id = null;
             } catch (ConnectException $e) {
-                $user->northstar_id = 'ERROR_CONNECTION';
+                $user->northstar_id = null;
             }
 
             $user->save();

--- a/tests/VotingTest.php
+++ b/tests/VotingTest.php
@@ -107,7 +107,7 @@ class VotingTest extends TestCase
         $this->seeInDatabase('users', [
             'first_name' => 'Puppet',
             'birthdate' => '1990-01-02',
-            'northstar_id' => 'CONFLICT',
+            'northstar_id' => null,
         ]);
     }
 


### PR DESCRIPTION
### What does this PR do?
- Previously if there was an error setting the Northstar ID we would replace it with a string. This PR replaces all of the string with `null`.
- The Votes Controller was having trouble passing tests because it used old Northstar package instead of Gateway, so I updated that.

### How can I test?
See `testSubmitVoteWithNorthstarConflict()` in `VotingTest.php`

Fixes https://github.com/DoSomething/voting-app/issues/542

cc: @sergii-tkachenko @jessleenyc 