### PR TITLE
Constrain logo to 800px wide (needed for larger SVGs).

### DIFF
--- a/resources/assets/sass/regions/_navigation.scss
+++ b/resources/assets/sass/regions/_navigation.scss
@@ -9,6 +9,7 @@ nav.primary {
 
   .navigation__logo {
     display: block;
+    max-width: 800px;
 
     img {
       max-width: 100%;


### PR DESCRIPTION
#### Changes
Larger SVGs expand to fill the max-width of the viewport... instead, we want logos to fit in a 800px wide bounding box so we don't accidentally upload massive images.

---
For review: @angaither @weerd 