### PR TITLE
Hotfix for an error on non-winner permalinks.

### DIFF
--- a/resources/views/candidates/show.blade.php
+++ b/resources/views/candidates/show.blade.php
@@ -6,7 +6,7 @@
 @section('meta_image', url($candidate->thumbnail))
 
 @section('content')
-    @if(setting('show_winners'))
+    @if(setting('show_winners') && isset($winner))
         @react('WinnerDetailView', ['item' => $winner])
     @else
         <div class="candidate">

--- a/resources/views/votes/form.blade.php
+++ b/resources/views/votes/form.blade.php
@@ -6,7 +6,7 @@
         <p class="heading -gamma">We'll post the results soon!</p>
     @else
         {{-- Winners being shown --}}
-        <p>{{ $winner->description or "WINNER_DESCRIPTION" }}</p>
+        <p>{{ $winner->description or "" }}</p>
     @endif
 
 {{-- If user is logged in... --}}


### PR DESCRIPTION
Hotfixed on production 12/27 in response to [New Relic report](https://rpm.newrelic.com/accounts/108038/incidents/24128775).

🌵